### PR TITLE
Set licensepool edition during directory import

### DIFF
--- a/scripts.py
+++ b/scripts.py
@@ -181,8 +181,11 @@ class DirectoryImportScript(Script):
                 metadata.links = links
                 metadata.formats = formats
 
-                license_pool, new = metadata.license_pool(self._db)
+                license_pool, new_license_pool = metadata.license_pool(self._db)
                 edition, new = metadata.edition(self._db)
+                if new_license_pool:
+                    license_pool.edition = edition
+
                 work, new = license_pool.calculate_work(known_edition=edition)
                 work.presentation_ready = True
 


### PR DESCRIPTION
OPDS entries weren't being created because the license pool didn't have an edition set prior to setting the correlated work's presentation. This prevented works from being loaded to the materialized view and shown in the feed.
