### PR TITLE
Preloaded content

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,6 +45,11 @@ def returns_problem_detail(f):
 def feed():
     return app.content_server.opds_feeds.feed()
 
+@app.route('/preload')
+@returns_problem_detail
+def preload():
+    return app.content_server.opds_feeds.preload()
+
 @app.route('/lookup')
 def lookup():
     return URNLookupController(app.content_server._db).work_lookup(ContentServerAnnotator)

--- a/config.py
+++ b/config.py
@@ -27,3 +27,10 @@ class Configuration(CoreConfiguration):
         Facets.AVAILABILITY_FACET_GROUP_NAME : Facets.AVAILABLE_OPEN_ACCESS,
         Facets.COLLECTION_FACET_GROUP_NAME : Facets.COLLECTION_FULL,
     }
+
+    PRELOADED_CONTENT = 'preloaded_content'
+
+@contextlib.contextmanager
+def temp_config(new_config=None):
+    with core_temp_config(new_config, [CoreConfiguration, Configuration]) as i:
+        yield i

--- a/controller.py
+++ b/controller.py
@@ -31,7 +31,10 @@ from core.lane import (
     Pagination,
 )
 from core.opds import AcquisitionFeed
-from opds import ContentServerAnnotator
+from opds import (
+    ContentServerAnnotator,
+    PreloadFeed,
+)
 
 
 class ContentServer(object):
@@ -86,3 +89,13 @@ class OPDSFeedController(ContentServerController):
             pagination=load_pagination_from_request()
         )
         return feed_response(opds_feed.content) 
+
+    def preload(self):
+        url = url_for("preload", _external=True)
+
+        opds_feed = PreloadFeed.page(
+            self._db, "Content to Preload", url,
+            annotator=self.annotator(),
+        )
+        return feed_response(opds_feed)
+        

--- a/scripts.py
+++ b/scripts.py
@@ -181,7 +181,7 @@ class DirectoryImportScript(Script):
 
                 license_pool, new_license_pool = metadata.license_pool(self._db)
                 edition, new = metadata.edition(self._db)
-                metadata.apply(edition, replace_rights=True)
+                metadata.apply(edition, replace_rights=True, replace_links=True)
                 if new_license_pool:
                     license_pool.edition = edition
 

--- a/scripts.py
+++ b/scripts.py
@@ -181,7 +181,7 @@ class DirectoryImportScript(Script):
 
                 license_pool, new_license_pool = metadata.license_pool(self._db)
                 edition, new = metadata.edition(self._db)
-                metadata.apply(edition)
+                metadata.apply(edition, replace_rights=True)
                 if new_license_pool:
                     license_pool.edition = edition
 

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -5,6 +5,10 @@ from nose.tools import (
 )
 
 from . import DatabaseTest
+from ..config import(
+    Configuration,
+    temp_config,
+)
 import os
 from ..controller import (
     ContentServer,
@@ -103,3 +107,17 @@ class TestFeedController(ControllerTest):
             response = self.content_server.opds_feeds.feed()
             assert "family_name" in response.data
             assert "Sylvia_Louise_Engdahl" in response.data
+
+    def test_preload(self):
+        SessionManager.refresh_materialized_views(self._db)
+
+        with temp_config() as config:
+            urn = self.english_2.primary_edition.primary_identifier.urn
+            config[Configuration.PRELOADED_CONTENT] = [urn]
+
+            with self.app.test_request_context("/"):
+                response = self.content_server.opds_feeds.preload()
+
+                assert self.english_1.title not in response.data
+                assert self.english_2.title in response.data
+                assert self.french_1.author not in response.data


### PR DESCRIPTION
A small change to fix importing Plympton books, and a new OPDS feed for preloaded content.

To use this, add "preloaded_content" to the config file, eg
```
"preloaded_content": [
    "urn:isbn:9781682280195",
    "urn:isbn:9781682280300",
    "urn:isbn:9781682280072"
]
```

This closes #25.