### PR TITLE
Remove ebookmaker from library requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,4 @@ uwsgi
 loggly-python-handler
 
 # Used only by content
-ebookmaker>=0.4.0a4
 pymarc


### PR DESCRIPTION
Very simple removal to avoid the GPL-licensed ebookmaker. Related to NYPL-Simplified/circulation#44.