### PR TITLE
Fix coverage providers

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -85,8 +85,8 @@ class OPDSFeedController(ContentServerController):
         opds_feed = AcquisitionFeed.page(
             self._db, "Open-Access Content", url, lane,
             annotator=self.annotator(),
-            facets=load_facets_from_request(),
-            pagination=load_pagination_from_request()
+            facets=load_facets_from_request(Configuration),
+            pagination=load_pagination_from_request(Configuration)
         )
         return feed_response(opds_feed.content) 
 

--- a/controller.py
+++ b/controller.py
@@ -86,7 +86,7 @@ class OPDSFeedController(ContentServerController):
             self._db, "Open-Access Content", url, lane,
             annotator=self.annotator(),
             facets=load_facets_from_request(Configuration),
-            pagination=load_pagination_from_request(Configuration)
+            pagination=load_pagination_from_request()
         )
         return feed_response(opds_feed.content) 
 

--- a/coverage.py
+++ b/coverage.py
@@ -41,7 +41,6 @@ class GutenbergEPUBCoverageProvider(CoverageProvider):
             self.gutenberg_mirror = None
             self.epub_mirror = None
 
-        input_source = DataSource.lookup(_db, DataSource.GUTENBERG)
         self.output_source = DataSource.lookup(
             _db, DataSource.GUTENBERG_EPUB_GENERATOR)        
         if callable(mirror_uploader):
@@ -49,8 +48,10 @@ class GutenbergEPUBCoverageProvider(CoverageProvider):
         self.uploader = mirror_uploader
 
         super(GutenbergEPUBCoverageProvider, self).__init__(
-            self.output_source.name, input_source, self.output_source,
-            workset_size=workset_size)
+            self.output_source.name, Identifier.GUTENBERG_ID, 
+            self.output_source,
+            workset_size=workset_size
+        )
 
     def process_item(self, identifier):
         edition = self.edition(identifier)

--- a/coverage.py
+++ b/coverage.py
@@ -71,7 +71,7 @@ class GutenbergEPUBCoverageProvider(CoverageProvider):
         if not edition.license_pool:
             return CoverageFailure(
                 self, identifier,
-                'No license pool for %r', edition,
+                'No license pool for %r' % edition,
                 transient=True,
             )
 

--- a/coverage.py
+++ b/coverage.py
@@ -5,7 +5,10 @@ import tempfile
 import urllib
 from nose.tools import set_trace
 from config import Configuration
-from core.coverage import CoverageProvider
+from core.coverage import (
+    CoverageProvider,
+    CoverageFailure,
+)
 from core.model import (
     get_one,
     DataSource,
@@ -49,21 +52,33 @@ class GutenbergEPUBCoverageProvider(CoverageProvider):
             self.output_source.name, input_source, self.output_source,
             workset_size=workset_size)
 
-    def process_edition(self, edition):
+    def process_item(self, identifier):
+        edition = self.edition(identifier)
+        if isinstance(edition, CoverageFailure):
+            return edition
         if edition.medium in (Edition.AUDIO_MEDIUM, Edition.VIDEO_MEDIUM):
             # There is no epub to mirror.
-            return True
-        identifier_obj = edition.primary_identifier
-        epub_path = self.epub_path_for(identifier_obj)
-        if not epub_path:
-            return False
-        license_pool = get_one(
-            self._db, LicensePool, identifier_id=identifier_obj.id)
+            return CoverageFailure(
+                self, identifier, 
+                'Medium "%s" does not support EPUB' % edition.medium,
+                transient=False,
+            )
+        epub_path = self.epub_path_for(identifier)
+        if isinstance(epub_path, CoverageFailure):
+            return epub_path
+        license_pool = edition.license_pool
+        if not edition.license_pool:
+            return CoverageFailure(
+                self, identifier,
+                'No license pool for %r', edition,
+                transient=True,
+            )
 
-        url = self.uploader.book_url(identifier_obj, 'epub')
+        url = self.uploader.book_url(identifier, 'epub')
         link, new = license_pool.add_link(
             Hyperlink.OPEN_ACCESS_DOWNLOAD, url, self.output_source,
-            Representation.EPUB_MEDIA_TYPE, None, epub_path)
+            Representation.EPUB_MEDIA_TYPE, None, epub_path
+        )
         representation = link.resource.representation
         representation.mirror_url = url
         self.uploader.mirror_one(representation)
@@ -72,24 +87,32 @@ class GutenbergEPUBCoverageProvider(CoverageProvider):
             Representation.EPUB_MEDIA_TYPE, DeliveryMechanism.NO_DRM, 
             link.resource
         )
-        return True
+        return identifier
 
     def epub_path_for(self, identifier):
         """Find the path to the best EPUB for the given identifier."""
         if identifier.type != Identifier.GUTENBERG_ID:
-            return None
+            return CoverageFailure(
+                self, identifier, "Not a Gutenberg book.", transient=False
+            )
         epub_directory = os.path.join(
-            self.epub_mirror, identifier.identifier)
+            self.epub_mirror, identifier.identifier
+        )
         if not os.path.exists(epub_directory):
-            self.log.warn(
-                "Expected EPUB directory %s does not exist!", epub_directory)
-            return None
+            return CoverageFailure(
+                self, identifier,
+                "Expected EPUB directory %s does not exist!" % epub_directory,
+                transient=True,
+            )
+
         files = os.listdir(epub_directory)
         epub_filename = self.best_epub_in(files)
         if not epub_filename:
-            self.log.warn(
-                "Could not find a good EPUB in %s!", epub_directory)
-            return None
+            return CoverageFailure(
+                self, identifier,
+                "Could not find a good EPUB in %s!", epub_directory,
+                transient=True
+            )
         return os.path.join(epub_directory, epub_filename)
 
     @classmethod

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -66,6 +66,15 @@ class TestFeedController(ControllerTest):
             assert self.english_2.title in response.data
             assert self.french_1.author in response.data
 
+            feed = feedparser.parse(response.data)
+            links = feed['feed']['links']
+
+            # Verify the default facets.
+            next_link = [x for x in links if x['rel'] == 'next'][0]['href']
+            assert 'order=added' in next_link
+            assert 'collection=full' in next_link
+            assert 'available=always' in next_link
+
     def test_multipage_feed(self):
         SessionManager.refresh_materialized_views(self._db)
 

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -8,10 +8,13 @@ from ..core.testing import DatabaseTest
 
 from ..coverage import GutenbergEPUBCoverageProvider
 from ..core.s3 import DummyS3Uploader
+from ..core.coverage import CoverageFailure
 from ..core.model import (
     get_one_or_create,
     DeliveryMechanism,
+    Edition,
     Hyperlink,
+    Identifier,
     LicensePool,
     Representation,
     Resource,
@@ -21,7 +24,7 @@ class DummyEPUBCoverageProvider(GutenbergEPUBCoverageProvider):
 
     def epub_path_for(self, identifier):
         if identifier.identifier.startswith('fail'):
-            return None
+            return CoverageFailure(self, identifier, "failure!", True)
         return "/oh/you/want/%s.epub" % identifier.identifier
 
 
@@ -31,33 +34,36 @@ class TestGutenbergEPUBCoverageProvider(DatabaseTest):
         super(TestGutenbergEPUBCoverageProvider, self).setup()
         self.provider = DummyEPUBCoverageProvider(
             self._db, mirror_uploader=DummyS3Uploader)
-
-    def test_process_edition_success(self):
-        edition = self._edition()
-        now = datetime.datetime.now()
-        pool, ignore = get_one_or_create(
-            self._db, LicensePool, edition=edition,
-            identifier=edition.primary_identifier,
-            open_access=True
+        self.real_provider = GutenbergEPUBCoverageProvider(
+            self._db, mirror_uploader=DummyS3Uploader
         )
-        
-        eq_(True, self.provider.process_edition(edition))
+
+    def test_process_item_success(self):
+        edition, pool = self._edition(with_license_pool=True)
+        # Set aside the default delivery mechanism that got associated with
+        # the license pool.
+        [lpm1] = pool.delivery_mechanisms
+
+        now = datetime.datetime.now()
+        identifier = edition.primary_identifier
+
+        # The coverage provider returned success.
+        eq_(identifier, self.provider.process_item(identifier))
 
         # Something was 'uploaded' to S3.
         [representation] = self.provider.uploader.uploaded
-        identifier = edition.primary_identifier
         eq_('http://s3.amazonaws.com/test.content.bucket/Gutenberg%%20ID/%s.epub' % identifier.identifier, representation.mirror_url)
         assert representation.mirrored_at > now
 
         # The edition has now been linked to a resource.
         [link] = edition.primary_identifier.links
         eq_(identifier, link.identifier)
-        eq_(pool, link.license_pool)
+        eq_(edition.license_pool, link.license_pool)
         eq_(Hyperlink.OPEN_ACCESS_DOWNLOAD, link.rel)
         eq_(self.provider.output_source, link.data_source)
 
-        # The license pool has a distribution mechanism.
-        [lpm] = link.license_pool.delivery_mechanisms
+        # A new distribution mechanism has been added to the pool
+        [lpm] = [x for x in link.license_pool.delivery_mechanisms if x != lpm1]
         mech = lpm.delivery_mechanism
         eq_(mech.content_type, Representation.EPUB_MEDIA_TYPE)
         eq_(mech.drm_scheme, DeliveryMechanism.NO_DRM)
@@ -69,10 +75,30 @@ class TestGutenbergEPUBCoverageProvider(DatabaseTest):
         eq_(self.provider.epub_path_for(identifier), 
             representation.local_content_path)
 
-    def test_process_edition_failure(self):
+    def test_epub_path_for_wrong_identifier_type(self):
+        identifier = self._identifier(Identifier.OVERDRIVE_ID)
+        failure = self.real_provider.epub_path_for(identifier)
+        assert isinstance(failure, CoverageFailure)
+        eq_('Not a Gutenberg book.', failure.exception)
+
+    def test_epub_path_for_nonexistent_directory(self):
+        identifier = self._identifier(Identifier.GUTENBERG_ID)
+        failure = self.real_provider.epub_path_for(identifier)
+        assert isinstance(failure, CoverageFailure)
+        assert failure.exception.startswith('Expected EPUB directory')
+        assert failure.exception.endswith('does not exist!')
+
+    def test_process_item_failure_wrong_medium(self):
+        edition, pool = self._edition(with_license_pool=True)
+        edition.medium = Edition.VIDEO_MEDIUM
+        failure = self.provider.process_item(edition.primary_identifier)
+        eq_('Medium "Video" does not support EPUB', failure.exception)
+
+    def test_process_item_failure(self):
         edition, pool = self._edition(with_license_pool=True)
         edition.primary_identifier.identifier = "fail1"
-        eq_(False, self.provider.process_edition(edition))
+        failure = self.provider.process_item(edition.primary_identifier)
+        eq_("failure!", failure.exception)
 
         # No resource has been created.
         eq_([], self._db.query(Hyperlink).all())


### PR DESCRIPTION
This branch fixes #43 by converting the content server's only CoverageProvider to take in Identifiers and return either an Identifier or a CoverageFailure.