### PR TITLE
Fix minor problems found while improving performance

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -5,6 +5,7 @@ import flask
 from core.util.flask_util import languages_for_request
 
 from core.problem_details import *
+from core.util.problem_detail import ProblemDetail
 
 from config import (
     Configuration,
@@ -82,11 +83,18 @@ class OPDSFeedController(ContentServerController):
         
         url = url_for("feed", _external=True)
 
+        facets = load_facets_from_request(Configuration)
+        if isinstance(facets, ProblemDetail):
+            return facets
+        pagination = load_pagination_from_request()
+        if isinstance(pagination, ProblemDetail):
+            return pagination
+
         opds_feed = AcquisitionFeed.page(
             self._db, "Open-Access Content", url, lane,
             annotator=self.annotator(),
-            facets=load_facets_from_request(),
-            pagination=load_pagination_from_request()
+            facets=facets,
+            pagination=pagination,
         )
         return feed_response(opds_feed.content) 
 

--- a/opds.py
+++ b/opds.py
@@ -24,15 +24,20 @@ class ContentServerAnnotator(VerboseAnnotator):
 
     @classmethod
     def annotate_work_entry(cls, work, active_license_pool, edition, identifier, feed, entry):
+        """Annotate the feed with all open-access links for this book."""
         if not active_license_pool.open_access:
             return
 
         rel = OPDSFeed.OPEN_ACCESS_REL
-        best_pool, best_link = active_license_pool.best_license_link
-        feed.add_link_to_entry(
-            entry, rel=rel, href=best_link.representation.mirror_url,
-            type=best_link.representation.media_type,
-        )
+        best_link = None
+        for resource in active_license_pool.open_access_links:
+            if not resource.representation:
+                continue
+            url = resource.representation.mirror_url
+            type = resource.representation.media_type
+            feed.add_link_to_entry(
+                entry, rel=rel, href=url, type=type
+            )
 
     @classmethod
     def default_lane_url(cls):


### PR DESCRIPTION
* If the pagination or faceting arguments are invalid, load_pagination_from_request() or load_facets_from_request() will return a ProblemDetail object, which should be returned immediately.

* If the LicensePool has more than one open-access link (as can happen with unglue.it books), display all of them, not just the 'best' one.
