### PR TITLE
Add py-bcrypt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ python-dateutil
 uwsgi
 loggly-python-handler
 cairosvg
+py-bcrypt
 
 # Used only by content
 pymarc


### PR DESCRIPTION
This is a new dependency added to core in NYPL-Simplified/server_core#183.