### PR TITLE
Workaround for Resource temporarily unavailable error

### DIFF
--- a/app.py
+++ b/app.py
@@ -72,5 +72,12 @@ if __name__ == '__main__':
     else:
         host = netloc
         port = 80
+
+    # Workaround for a "Resource temporarily unavailable" error when
+    # running in debug mode with the global socket timeout set by isbnlib
+    if debug:
+        import socket
+        socket.setdefaulttimeout(None)
+
     app.content_server.log.info("Starting app on %s:%s", host, port)
     app.run(debug=debug, host=host, port=port)


### PR DESCRIPTION
I added this to circulation a long time ago (https://github.com/NYPL-Simplified/circulation/pull/6) but never copied it here.