### PR TITLE
Standard ebooks update

### DIFF
--- a/bin/standard_ebooks_monitor
+++ b/bin/standard_ebooks_monitor
@@ -11,5 +11,6 @@ from core.model import DataSource
 OPDSImportScript(
     "https://standardebooks.org/opds/all", 
     DataSource.STANDARD_EBOOKS, 
-    OPDSImporterWithS3Mirror
+    OPDSImporterWithS3Mirror,
+    immediately_presentation_ready=True,
 ).run()

--- a/gutenberg.py
+++ b/gutenberg.py
@@ -89,63 +89,6 @@ class GutenbergAPI(object):
         self.catalog_path = os.path.join(self.data_directory, self.FILENAME)
         self.log = logging.getLogger("Gutenberg API")
 
-    @classmethod
-    def url_to_mirror_path(cls, url):
-        """Convert a URL as seen in the RDF file to the corresponding
-        path in the local archive of a Gutenberg mirror.
-        """
-        parsed = urlparse(url)
-        if parsed.hostname not in ('www.gutenberg.org', 'gutenberg.org'):
-            raise ValueError("Not a Gutenberg URL: %s" % url)
-
-        mirror = cls.GUTENBERG_ORIGINAL_MIRROR
-        if parsed.path.startswith('/files/'):
-            # /files/8594/8594.txt
-            #     =>
-            # /8/5/9/8594/8494.txt           
-            text_id = cls.EPUB_ID.search(parsed.path).groups()[0]
-            path_parts = [i for i in text_id[:-1]]
-            new_path_prefix = os.path.join(*path_parts) 
-            new_path = parsed.path.replace(
-                '/files/', "/" + new_path_prefix + "/", 1)
-            mirror = cls.GUTENBERG_ORIGINAL_MIRROR
-        elif parsed.path.startswith('/dirs/'):
-            # /dirs/etext05/8ivn110.zip
-            #     =>
-            # /etext05/8ivn110.zip
-            mirror = cls.GUTENBERG_ORIGINAL_MIRROR
-            new_path = parsed.path.replace('/dirs/', '/', 1)
-        elif parsed.path.startswith('/ebooks/'):
-            mirror = cls.GUTENBERG_EBOOK_MIRROR
-            text_id = cls.EPUB_ID.search(parsed.path).groups()[0]
-            if '.epub' in parsed.path:
-                # /ebooks/8594.epub.images
-                #     =>
-                # /8594/pg8594-images.epub
-                #
-                # /ebooks/8605.epub.noimages
-                #     =>
-                # /8605/pg8605.epub
-                if 'noimages' in parsed.path:
-                    new_path = "/%(text_id)s/pg%(text_id)s.epub" 
-                else:
-                    new_path = "/%(text_id)s/pg%(text_id)s-images.epub"
-                new_path = new_path % dict(text_id=text_id)
-            else:
-                # /ebooks/8596.plucker
-                #     =>
-                # /8596/pg8596.plucker
-                new_path = parsed.path.replace(
-                    "/ebooks/", "/" + text_id + "/pg")
-        elif parsed.path.startswith('/cache/epub/'):
-            mirror = cls.GUTENBERG_EBOOK_MIRROR
-            # /cache/epub/38044/pg38044.cover.medium.jpg 
-            #     =>
-            # /38044/pg38044.cover.medium.jpg 
-            new_path = parsed.path.replace('/cache/epub/', '/', 1)
-
-        return mirror, new_path
-
     def update_catalog(self):
         """Download the most recent Project Gutenberg catalog
         from a randomly selected mirror.

--- a/opds.py
+++ b/opds.py
@@ -18,6 +18,10 @@ from core.model import (
     Edition,
     LicensePool,
 )
+from core.lane import (
+    Facets,
+    Pagination,
+)
 from config import Configuration
 
 class ContentServerAnnotator(VerboseAnnotator):
@@ -42,16 +46,27 @@ class ContentServerAnnotator(VerboseAnnotator):
     def default_lane_url(cls):
         return cdn_url_for("feed", _external=True)
 
+    def top_level_title(self):
+        return "All Books"
+
+    def lane_url(self, lane, facets=None, pagination=None):
+        if not facets:
+            facets = Facets.default()
+        if not pagination:
+            pagination = Pagination.default()
+        return self.feed_url(lane, facets, pagination)
+
     def feed_url(self, lane, facets, pagination):
         kwargs = dict(facets.items())
         kwargs.update(dict(pagination.items()))
-        if lane.license_source:
+        if lane and lane.license_source:
             view = "feed_from_license_source"
             kwargs['license_source_name'] = lane.license_source.name
         else:
             view = "feed"
-            kwargs['lane'] = lane.name
-            kwargs['languages'] = lane.languages
+            if lane:
+                kwargs['lane'] = lane.name
+                kwargs['languages'] = lane.languages
         return cdn_url_for(view, _external=True, **kwargs)
 
 class AllCoverLinksAnnotator(ContentServerAnnotator):

--- a/opds.py
+++ b/opds.py
@@ -18,10 +18,7 @@ from core.model import (
     Edition,
     LicensePool,
 )
-from core.lane import (
-    Facets,
-    Pagination,
-)
+
 from config import Configuration
 
 class ContentServerAnnotator(VerboseAnnotator):
@@ -49,24 +46,16 @@ class ContentServerAnnotator(VerboseAnnotator):
     def top_level_title(self):
         return "All Books"
 
-    def lane_url(self, lane, facets=None, pagination=None):
-        if not facets:
-            facets = Facets.default()
-        if not pagination:
-            pagination = Pagination.default()
-        return self.feed_url(lane, facets, pagination)
-
     def feed_url(self, lane, facets, pagination):
         kwargs = dict(facets.items())
         kwargs.update(dict(pagination.items()))
-        if lane and lane.license_source:
+        if lane.license_source:
             view = "feed_from_license_source"
             kwargs['license_source_name'] = lane.license_source.name
         else:
             view = "feed"
-            if lane:
-                kwargs['lane'] = lane.name
-                kwargs['languages'] = lane.languages
+            kwargs['lane'] = lane.name
+            kwargs['languages'] = lane.languages
         return cdn_url_for(view, _external=True, **kwargs)
 
 class AllCoverLinksAnnotator(ContentServerAnnotator):

--- a/opds_import.py
+++ b/opds_import.py
@@ -13,7 +13,7 @@ class UnglueItOPDSImporter(OPDSImporterWithS3Mirror):
             cutoff_date=None, immediately_presentation_ready=True
     ):
         # Override some of the provided arguments.
-        super(UnglueItOPDSImporter, self).import_from_feed(
+        return super(UnglueItOPDSImporter, self).import_from_feed(
             feed, even_if_no_author=True, cutoff_date=cutoff_date,
             immediately_presentation_ready=True
         )
@@ -34,7 +34,8 @@ class UnglueItOPDSImporter(OPDSImporterWithS3Mirror):
                     other_links.append(deepcopy(link))
 
             if len(book_links) > 1:
-                # Create a different metadata object for each book link
+                # Create a different metadata object for each book link. This is necessary because
+                # the book links may come from different sources and have different rights.
                 for link in book_links:
                     metadata_copy = deepcopy(metadata_obj)
                     metadata_copy.links = [link] + other_links

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,20 +2,7 @@ from nose.tools import set_trace
 
 from ..core.testing import (
     DatabaseTest,
-    _setup,
-    _teardown,
+    package_setup,
 )
 
-class ContentDBInfo(object):
-    connection = None
-    engine = None
-    transaction = None
-
-DatabaseTest.DBInfo = ContentDBInfo
-
-def setup():
-    _setup(ContentDBInfo)
-
-def teardown():
-    _teardown(ContentDBInfo)
-
+package_setup()

--- a/tests/test_gutenberg.py
+++ b/tests/test_gutenberg.py
@@ -23,30 +23,6 @@ from ..gutenberg import (
 )
 from . import DatabaseTest
 
-class TestGutenbergAPI(DatabaseTest):
-
-    def test_url_to_mirror_path(self):
-
-        original = GutenbergAPI.GUTENBERG_ORIGINAL_MIRROR
-        ebooks = GutenbergAPI.GUTENBERG_EBOOK_MIRROR
-
-        def e(expect, url):
-            eq_(expect, GutenbergAPI.url_to_mirror_path(url))
-
-        e((original, "/8/5/9/8594/8594-h.zip"),
-          "http://www.gutenberg.org/files/8594/8594-h.zip")
-        e((original, "/etext05/8wfrt10.zip"),
-          "http://www.gutenberg.org/dirs/etext05/8wfrt10.zip")
-
-        e((ebooks, "/8594/pg8594.plucker"),
-          "http://www.gutenberg.org/ebooks/8594.plucker")
-        e((ebooks, '/8594/pg8594-images.epub'),
-          "http://www.gutenberg.org/ebooks/8594.epub.images")
-        e((ebooks, '/8594/pg8594.epub'),
-          "http://www.gutenberg.org/ebooks/8594.epub.noimages")
-        e((ebooks, '/38044/pg38044.cover.medium.jpg'),
-          "http://www.gutenberg.org/cache/epub/38044/pg38044.cover.medium.jpg")
-
 class TestGutenbergMetadataExtractor(DatabaseTest):
 
     def sample_data(self, filename):


### PR DESCRIPTION
This branch: 
- updates the content server to work with the latest version of core
- removes a method for creating gutenberg mirror urls that is no longer used
- marks standard ebooks imports as presentation ready
- fixes unglue.it importer