### PR TITLE
Added teardown_request.

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,6 +41,18 @@ def returns_problem_detail(f):
         return v
     return decorated
 
+@app.teardown_request
+def shutdown_session(exception):
+    if (hasattr(app, 'content_server',)
+        and hasattr(app.content_server, '_db')
+        and app.content_server._db
+    ):
+        if exception:
+            app.content_server._db.rollback()
+        else:
+            app.content_server._db.commit()
+            
+
 @app.route('/')
 @returns_problem_detail
 def feed():


### PR DESCRIPTION
The content server didn't have anything committing or rolling back the database, so at the end of a request the last query would go into 'idle in transaction' state and keep its locks on database tables. Other requests that needed the locks would hang until they were killed by uwsgi, but it would leave their database connections open so eventually the database would run out of connections.

If this works the metadata wrangler may need the same thing.