### PR TITLE
Excluded mysterious files that cause errors from gutenberg rsync.

### DIFF
--- a/bin/update_generated_mirror
+++ b/bin/update_generated_mirror
@@ -1,2 +1,2 @@
 #!/bin/sh
-rsync -av --exclude=*.mobi --exclude=*.html --exclude=*.plucker* --exclude=*.jar --exclude=*.xapian --exclude=*.utf8 --exclude=*.png --exclude=*.gzip --exclude=*.jpg --exclude=*.log --exclude=*.rdf ftp@ftp.ibiblio.org::gutenberg-epub $DATA_DIRECTORY/Gutenberg/gutenberg-epub
+rsync -av --exclude=*.mobi --exclude=*.html --exclude=*.plucker* --exclude=*.jar --exclude=*.xapian --exclude=*.utf8 --exclude=*.png --exclude=*.gzip --exclude=*.jpg --exclude=*.log --exclude=*.rdf --exclude='*/mbt-*' ftp@ftp.ibiblio.org::gutenberg-epub $DATA_DIRECTORY/Gutenberg/gutenberg-epub


### PR DESCRIPTION
I'm not sure what the mbt-* files are but gutenberg has an example here http://www.gutenberg.org/wiki/Gutenberg:Mirroring_How-To that excludes them, and sometimes they cause errors.