### PR TITLE
Let calculate_work figure out what the presentation edition is.

### DIFF
--- a/gutenberg.py
+++ b/gutenberg.py
@@ -356,10 +356,7 @@ class GutenbergRDFExtractor(object):
 
         # Ensure that an open-access LicensePool exists for this book.
         license_pool, new_license_pool = metadata.license_pool(_db)
-        if new_license_pool:
-            license_pool.edition = edition
-        license_pool.calculate_work(known_edition=edition)
-
+        license_pool.calculate_work()
         return edition, license_pool, new
 
 


### PR DESCRIPTION
This branch updates the content server's submodule and fixes some test failures caused by the new `calculate_work()` implementation. The problem really happened a few branches earlier, when we renamed `LicensePool.edition` to `LicensePool.presentation_edition`. Passing in a `known_edition` other than the presentation edition for the LicensePool fails a sanity check, which raises an exception. Setting `edition` instead of `presentation_edition` means that the presentation edition for the LicensePool is None, but `known_edition` is not None, so :boom: 

I could have fixed this by changing the variable name, but it's simpler to just stop using `known_edition` and let `calculate_work` figure out what the presentation edition is. I believe the time for `known_edition` has passed and we should get rid of it. We always know what `known_edition` is--it's the presentation edition we get by calling `set_presentation_edition()`.