### PR TITLE
Fix travis build

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "core"]
 	path = core
-	url = git@github.com:NYPL/Simplified-server-core.git
+	url = git@github.com:NYPL-Simplified/server_core.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ python:
 
 cache: pip
 
+git:
+  submodules: false
+
+before_install:
+  - git config submodule.core.url https://github.com/NYPL-Simplified/server_core.git
+  - git submodule update --init --recursive
+
 install:
   - pip install -r requirements.txt
   - cp config.json.sample config.json


### PR DESCRIPTION
This rolls back the submodule update (which breaks a lot of tests) and forces Travis to use the public url.