### PR TITLE
Fix epub coverage provider

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -30,7 +30,12 @@ class GutenbergEPUBCoverageProvider(CoverageProvider):
     uploading it.
     """
 
-    def __init__(self, _db, batch_size=5, mirror_uploader=S3Uploader):
+    def __init__(self, _db, batch_size=5, mirror_uploader=S3Uploader,
+                 input_identifier_types=None, **kwargs):
+        """
+        :param input_identifier_types: Ignored, since we always
+        and exclusively manage Gutenberg IDs.
+        """
         data_directory = Configuration.data_directory()
 
         if data_directory:
@@ -52,7 +57,8 @@ class GutenbergEPUBCoverageProvider(CoverageProvider):
         super(GutenbergEPUBCoverageProvider, self).__init__(
             output_source.name, Identifier.GUTENBERG_ID, 
             output_source,
-            batch_size=batch_size
+            batch_size=batch_size,
+            **kwargs
         )
 
     def process_item(self, identifier):
@@ -116,7 +122,7 @@ class GutenbergEPUBCoverageProvider(CoverageProvider):
         if not epub_filename:
             return CoverageFailure(
                 identifier,
-                "Could not find a good EPUB in %s!", epub_directory,
+                "Could not find a good EPUB in %s!" % epub_directory,
                 data_source=self.output_source,
                 transient=True
             )

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -20,6 +20,9 @@ from ..core.model import (
     Representation,
     Resource,
 )
+from ..core.scripts import (
+    RunCoverageProviderScript
+)
 
 class DummyEPUBCoverageProvider(GutenbergEPUBCoverageProvider):
 
@@ -36,6 +39,11 @@ class TestGutenbergEPUBCoverageProvider(DatabaseTest):
         self.provider = DummyEPUBCoverageProvider(
             self._db, mirror_uploader=DummyS3Uploader)
 
+    def test_can_instantiate_from_script(self):
+        script = RunCoverageProviderScript(
+            DummyEPUBCoverageProvider, self._db, []
+        )
+        assert isinstance(DummyEPUBCoverageProvider, script.provider)
 
     def test_process_item_success(self):
         edition, pool = self._edition(with_license_pool=True)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -41,9 +41,10 @@ class TestGutenbergEPUBCoverageProvider(DatabaseTest):
 
     def test_can_instantiate_from_script(self):
         script = RunCoverageProviderScript(
-            DummyEPUBCoverageProvider, self._db, []
+            DummyEPUBCoverageProvider, self._db, [], 
+            mirror_uploader=DummyS3Uploader
         )
-        assert isinstance(DummyEPUBCoverageProvider, script.provider)
+        assert isinstance(script.provider, DummyEPUBCoverageProvider)
 
     def test_process_item_success(self):
         edition, pool = self._edition(with_license_pool=True)


### PR DESCRIPTION
This branch brings the EPUBCoverageProvider up to date with the new CoverageProvider constructor arguments, and adds a test that RunCoverageProviderScript properly instantiates the EPUBCoverageProvider, which will notify us immediately if this breaks again.