### PR TITLE
Handle edge cases that show up in unglue.it feeds

### DIFF
--- a/bin/unglue_it_monitor
+++ b/bin/unglue_it_monitor
@@ -8,9 +8,10 @@ sys.path.append(os.path.abspath(package_dir))
 from core.scripts import OPDSImportScript
 from core.opds_import import OPDSImporterWithS3Mirror
 from core.model import DataSource
+from unglueit import UnglueItImporter
 OPDSImportScript(
     "https://unglue.it/api/opds/epub/",
     DataSource.UNGLUE_IT,
-    OPDSImporterWithS3Mirror,
+    UnglueItImporter,
     immediately_presentation_ready=True,
 ).run()

--- a/controller.py
+++ b/controller.py
@@ -105,7 +105,6 @@ class OPDSFeedController(ContentServerController):
             annotator=self.annotator(),
             facets=facets,
             pagination=pagination,
-            force_refresh=True,
         )
         return feed_response(opds_feed.content) 
         

--- a/controller.py
+++ b/controller.py
@@ -105,6 +105,7 @@ class OPDSFeedController(ContentServerController):
             annotator=self.annotator(),
             facets=facets,
             pagination=pagination,
+            force_refresh=True,
         )
         return feed_response(opds_feed.content) 
         

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,0 +1,23 @@
+from nose.tools import (
+    assert_raises,
+    set_trace,
+)
+from . import DatabaseTest
+from ..opds import ContentServerAnnotator
+from ..core.opds import UnfulfillableWork
+
+class TestAnnotator(DatabaseTest):
+
+    def test_unfulfillable_work_raises_exception(self):
+        work = self._work(with_license_pool=True)
+        # This work has a LicensePool but no licenses and no
+        # open-access downloads. The ContentServerAnnotator will raise
+        # UnfulfillableWork when asked to annotate a feed for this
+        # work.
+        assert_raises(
+            UnfulfillableWork, 
+            ContentServerAnnotator.annotate_work_entry,
+            work, work.license_pools[0], work.presentation_edition,
+            work.presentation_edition.primary_identifier,
+            None, None
+        )

--- a/unglueit.py
+++ b/unglueit.py
@@ -1,0 +1,43 @@
+from nose.tools import set_trace
+import requests
+import urlparse
+from core.model import (
+    Representation
+)
+from core.opds_import import OPDSImporterWithS3Mirror
+
+class UnglueItImporter(OPDSImporterWithS3Mirror):
+
+    def _check_for_gutenberg_first(self, url, headers, **kwargs):
+        """Make a HEAD request for the given URL to make sure
+        it doesn't redirect to gutenberg.org.
+        """
+        parsed = urlparse.urlparse(url)
+        if parsed.netloc.endswith('unglue.it'):
+            # It might be a redirect. Make a HEAD request to see where
+            # it leads.
+            head_response = requests.head(url, headers=headers)
+            if head_response.status_code / 100 == 3:
+                # Yes, it's a redirect.
+                location = head_response.headers.get('location')
+                if location:
+                    parsed = urlparse.urlparse(location)
+                    if parsed.netloc.endswith('gutenberg.org'):
+                        # If we make this request we're going to be in
+                        # for some trouble, and we won't even get
+                        # anything useful. Act as though we got an
+                        # unappetizing representation.
+                        self.log.info("Not making request to gutenberg.org.")
+                        return (
+                            200, 
+                            {"content-type" :
+                             "application/vnd.librarysimplified-clickthrough"},
+                            "Gated behind Gutenberg click-through"
+                        )
+        return Representation.simple_http_get(url, headers, **kwargs)
+
+    def __init__(self, _db, default_data_source, **kwargs):
+        kwargs['http_get'] = self._check_for_gutenberg_first
+        super(UnglueItImporter, self).__init__(
+            _db, default_data_source, **kwargs
+        )


### PR DESCRIPTION
This branch fixes two problems I encountered with the unglue.it OPDS import. (Many more are fixed in https://github.com/NYPL-Simplified/server_core/pull/340, the corresponding core branch.)

1. A lot of unglue.it links point to Project Gutenberg epubs. Following those links doesn't get you an epub -- it gets you a Gutenberg clickthrough. We can treat this as an unexpected media type -- we wanted epub and we got HTML -- except that if you hit a bunch of these links Gutenberg bans your IP address. So it's better not to make the request in the first place. I created a custom importer that makes a HEAD request to every unglue.it open-access link to see if it redirects to Gutenberg.
2. It might happen that every single one of a book's delivery mechanisms is provided by an open-access resource that can't be mirrored. If this happens, I now raise `UnfulfillableWork()`. This is a better solution than refusing to store the book's delivery mechanisms in the first place, since there's always the possibility the resource might become mirrorable later on.

