### PR TITLE
Add facets to static feeds

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -62,6 +62,10 @@ class ContentServerAnnotator(VerboseAnnotator):
     def top_level_title(self):
         return "All Books"
 
+    def facet_url(self, facets):
+        kwargs = dict(facets.items())
+        return cdn_url_for('feed', _external=True, **kwargs)
+
     def feed_url(self, lane, facets, pagination):
         kwargs = dict(facets.items())
         kwargs.update(dict(pagination.items()))

--- a/opds.py
+++ b/opds.py
@@ -62,10 +62,6 @@ class ContentServerAnnotator(VerboseAnnotator):
     def top_level_title(self):
         return "All Books"
 
-    def facet_url(self, facets):
-        kwargs = dict(facets.items())
-        return cdn_url_for('feed', _external=True, **kwargs)
-
     def feed_url(self, lane, facets, pagination):
         kwargs = dict(facets.items())
         kwargs.update(dict(pagination.items()))
@@ -100,3 +96,26 @@ class AllCoverLinksAnnotator(ContentServerAnnotator):
             if cover.scaled_path:
                 thumbnails.append(cover.scaled_path)
         return thumbnails, full
+
+
+class StaticFeedAnnotator(ContentServerAnnotator):
+
+    """An Annotator to work with static feeds generated via script"""
+
+    def __init__(self, base_url, base_filename, default_order=None):
+        self.default_order = default_order
+        self.base_url = base_url
+
+        if base_filename.endswith('.opds'):
+            base_filename = base_filename[:-5]
+        self.base_filename = base_filename
+
+    def facet_url(self, facets):
+        ordered_by = list(facets.items())[0][1]
+
+        filename = self.base_filename
+        if ordered_by != self.default_order:
+            filename += ('_'+ordered_by)
+        filename += '.opds'
+
+        return self.base_url + '/' + filename

--- a/scripts.py
+++ b/scripts.py
@@ -34,7 +34,6 @@ from core.opds import AcquisitionFeed
 from core.s3 import S3Uploader
 from core.util import fast_query_count
 
-from controller import ContentServer
 from coverage import GutenbergEPUBCoverageProvider
 from marc import MARCExtractor
 from monitor import GutenbergMonitor
@@ -444,27 +443,11 @@ class CustomOPDSFeedGenerationScript(Script):
             )
 
             # Add the facet links to the feed.
-            context = self.create_app_context(feed_id)
             for link_args in AcquisitionFeed.facet_links(annotator, facet_obj):
                 AcquisitionFeed.add_link_to_feed(feed=feed.feed, **link_args)
-            context.pop()
 
             key = base_filename
             if ordered_by != self.DEFAULT_ORDER:
                 key += ('_' + ordered_by)
             feeds[key] = feed
         return feeds
-
-    def create_app_context(self, feed_id):
-        """Push a fake app context so the feed can create links
-
-        :return: The app context, so that it can be removed later.
-        """
-        os.environ['AUTOINITIALIZE'] = 'False'
-        from app import app
-        del os.environ['AUTOINITIALIZE']
-
-        app.content_server = ContentServer(_db=self._db)
-        context = app.test_request_context(base_url=feed_id)
-        context.push()
-        return context

--- a/scripts.py
+++ b/scripts.py
@@ -3,12 +3,16 @@ import csv
 import os
 import re
 from datetime import datetime
+from nose.tools import set_trace
 from sqlalchemy.orm import lazyload
 
+from core.classifier import Classifier
 from core.scripts import Script
-from monitor import GutenbergMonitor
-from coverage import (
-    GutenbergEPUBCoverageProvider,
+from core.metadata_layer import (
+    LinkData,
+    FormatData,
+    CirculationData,
+    ReplacementPolicy,
 )
 from core.model import (
     DataSource,
@@ -24,21 +28,14 @@ from core.model import (
     RightsStatus,
     Work,
 )
-from core.classifier import Classifier
 from core.monitor import PresentationReadyMonitor
-
-from core.metadata_layer import (
-    LinkData,
-    FormatData,
-    CirculationData,
-    ReplacementPolicy,
-)
 from core.opds import AcquisitionFeed
 from core.s3 import S3Uploader
 
+from coverage import GutenbergEPUBCoverageProvider
 from marc import MARCExtractor
+from monitor import GutenbergMonitor
 from opds import ContentServerAnnotator
-from nose.tools import set_trace
 
 
 class GutenbergMonitorScript(Script):

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,5 +1,6 @@
 import feedparser
 from nose.tools import set_trace, eq_
+from os import path
 
 from . import DatabaseTest
 
@@ -76,17 +77,19 @@ class TestCustomOPDSFeedGenerationScript(DatabaseTest):
         )
 
         eq_(True, isinstance(result, dict))
-        eq_(['default', 'ordered-by-author'], sorted(result.keys()))
-        for feed in result.values():
+        eq_(['test-feed', 'test-feed_author'], sorted(result.keys()))
+        for key, feed in result.items():
             eq_(True, isinstance(feed, AcquisitionFeed))
             parsed = feedparser.parse(unicode(feed))
             [active_facet_link] = [l for l in parsed.feed.links if l.get('activefacet')]
-
-            if active_facet_link.get('title') == 'Title':
-                # The entries should be sorted by title.
+            if key == 'test-feed':
+                # The entries are sorted by title, by default.
+                eq_('Title', active_facet_link.get('title'))
                 titles = [e.title for e in parsed.entries]
                 eq_(['Alpha', 'Omega', 'Zeta'], titles)
 
-            if active_facet_link.get('title') == 'Author':
+            if key == 'test-feed_author':
+                # The entries can also be sorted by author.
+                eq_('Author', active_facet_link.get('title'))
                 authors = [e.simplified_sort_name for e in parsed.entries]
                 eq_(['Iota', 'Phi', 'Theta'], authors)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -38,13 +38,10 @@ class TestCustomOPDSFeedGenerationScript(DatabaseTest):
         uploader = DummyS3Uploader()
         cmd_args = ['-t', 'Test Feed', '-d', 'mta.librarysimplified.org',
                     '-u', no_pool, urn1, urn2]
-
-        # Run the script.
         script.run(uploader=uploader, cmd_args=cmd_args)
 
         # Feeds are created and uploaded for the main feed and its facets.
         eq_(2, len(uploader.content))
-
         for feed in uploader.content:
             parsed = feedparser.parse(feed)
             eq_(u'mta.librarysimplified.org', parsed.feed.id)
@@ -59,7 +56,7 @@ class TestCustomOPDSFeedGenerationScript(DatabaseTest):
             [entry] = parsed.entries
             eq_(requested.title, entry.title)
 
-        # There should also be a representations saved to the database
+        # There should also be a Representation saved to the database
         # for each feed.
         representations = self._db.query(Representation).all()
         # Representations with "Dummy content" are created in _license_pool()

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -3,6 +3,12 @@ from nose.tools import set_trace, eq_
 
 from . import DatabaseTest
 
+from ..core.model import (
+    Edition,
+    Representation,
+    Work,
+)
+from ..core.opds import AcquisitionFeed
 from ..core.s3 import DummyS3Uploader
 
 from ..scripts import CustomOPDSFeedGenerationScript
@@ -33,11 +39,57 @@ class TestCustomOPDSFeedGenerationScript(DatabaseTest):
         cmd_args = ['-t', 'Test Feed', '-d', 'mta.librarysimplified.org',
                     '-u', no_pool, urn1, urn2]
 
+        # Run the script.
         script.run(uploader=uploader, cmd_args=cmd_args)
-        parsed = feedparser.parse(uploader.content[0])
-        eq_(u'mta.librarysimplified.org', parsed.feed.id)
-        eq_(u'Test Feed', parsed.feed.title)
 
-        # Only the non-suppressed, license_pooled work we requested is in the entry feed.
-        [entry] = parsed.entries
-        eq_(requested.title, entry.title)
+        # Feeds are created and uploaded for the main feed and its facets.
+        eq_(2, len(uploader.content))
+
+        for feed in uploader.content:
+            parsed = feedparser.parse(feed)
+            eq_(u'mta.librarysimplified.org', parsed.feed.id)
+            eq_(u'Test Feed', parsed.feed.title)
+
+            # There are links for the different facets.
+            links = parsed.feed.links
+            eq_(2, len([l for l in links if l.get('facetgroup')]))
+
+            # Only the non-suppressed, license_pooled works we requested
+            # are in the entry feed.
+            [entry] = parsed.entries
+            eq_(requested.title, entry.title)
+
+        # There should also be a representations saved to the database
+        # for each feed.
+        representations = self._db.query(Representation).all()
+        # Representations with "Dummy content" are created in _license_pool()
+        # for each working. We'll ignore these.
+        representations = [r for r in representations if r.content != 'Dummy content']
+        eq_(2, len(representations))
+
+    def test_create_faceted_feeds(self):
+        omega = self._work(title='Omega', authors='Iota', with_open_access_download=True)
+        alpha = self._work(title='Alpha', authors='Theta', with_open_access_download=True)
+        zeta = self._work(title='Zeta', authors='Phi', with_open_access_download=True)
+
+        qu = self._db.query(Work, Edition).join(Work.presentation_edition)
+        script = CustomOPDSFeedGenerationScript(_db=self._db)
+        result = script.create_faceted_feeds(
+            qu, 'Test Feed', 'https://mta.librarysimplified.org'
+        )
+
+        eq_(True, isinstance(result, dict))
+        eq_(['default', 'ordered-by-author'], sorted(result.keys()))
+        for feed in result.values():
+            eq_(True, isinstance(feed, AcquisitionFeed))
+            parsed = feedparser.parse(unicode(feed))
+            [active_facet_link] = [l for l in parsed.feed.links if l.get('activefacet')]
+
+            if active_facet_link.get('title') == 'Title':
+                # The entries should be sorted by title.
+                titles = [e.title for e in parsed.entries]
+                eq_(['Alpha', 'Omega', 'Zeta'], titles)
+
+            if active_facet_link.get('title') == 'Author':
+                authors = [e.simplified_sort_name for e in parsed.entries]
+                eq_(['Iota', 'Phi', 'Theta'], authors)


### PR DESCRIPTION
There are a lot of assumptions in this branch, including:
- This script is only intended for use against open access content, rendering the Availability facet useless.
- This script will only be used for collections that have been hand-selected by and/or sourced from the finest open source distributors, rendering the Collection facet unnecessary.
- The feeds will be small enough not to require too many options for ordering or pagination.

If these assumptions turn out to be wrong, changes can be made. Meanwhile, the branch creates faceted static feeds to represent a custom list of URNs, allowing collections to be sorted by either title (default) or author.

Fixes #85.