### PR TITLE
Add pagination to static feeds

### DIFF
--- a/lanes.py
+++ b/lanes.py
@@ -1,0 +1,27 @@
+from core.model import (
+    LicensePool,
+    Work,
+)
+from core.lane import QueryGeneratedLane
+
+class IdentifiersLane(QueryGeneratedLane):
+
+    def __init__(self, _db, identifiers, lane_name, parent=None):
+        if not identifiers:
+            raise ValueError(
+                "IdentifierGeneratedLane can't be created without Identifiers"
+            )
+        self.identifiers = identifiers
+        full_name = display_name = lane_name
+        super(IdentifiersLane, self).__init__(
+            _db, full_name, display_name=display_name
+        )
+
+    def lane_query_hook(self, qu, work_model=Work):
+        if work_model != Work:
+            qu = qu.join(LicensePool.identifier)
+
+        qu = Work.from_identifiers(
+            self._db, self.identifiers, base_query=qu
+        )
+        return qu

--- a/opds.py
+++ b/opds.py
@@ -110,12 +110,28 @@ class StaticFeedAnnotator(ContentServerAnnotator):
             base_filename = base_filename[:-5]
         self.base_filename = base_filename
 
-    def facet_url(self, facets):
+    def filename_facet_segment(self, facets):
         ordered_by = list(facets.items())[0][1]
-
-        filename = self.base_filename
         if ordered_by != self.default_order:
-            filename += ('_'+ordered_by)
-        filename += '.opds'
+            return '_' + ordered_by
+        return ''
 
-        return self.base_url + '/' + filename
+    def facet_url(self, facets):
+        """Incoporate order facets into filenames for static feeds
+        """
+        filename = self.base_filename
+        filename += self.filename_facet_segment(facets)
+
+        return self.base_url + '/' + filename + '.opds'
+
+    def feed_url(self, facets, pagination):
+        """Incorporate pages into filenames for static feeds
+        """
+        filename = self.base_filename
+        filename += self.filename_facet_segment(facets)
+
+        page_number = (pagination.offset / pagination.size) + 1
+        if page_number > 1:
+            filename += ('_%i' % page_number)
+
+        return self.base_url + '/' + filename + '.opds'

--- a/opds.py
+++ b/opds.py
@@ -110,6 +110,9 @@ class StaticFeedAnnotator(ContentServerAnnotator):
             base_filename = base_filename[:-5]
         self.base_filename = base_filename
 
+    def default_lane_url(self):
+        return self.base_url + '/' + self.base_filename + '.opds'
+
     def filename_facet_segment(self, facets):
         ordered_by = list(facets.items())[0][1]
         if ordered_by != self.default_order:
@@ -124,7 +127,7 @@ class StaticFeedAnnotator(ContentServerAnnotator):
 
         return self.base_url + '/' + filename + '.opds'
 
-    def feed_url(self, facets, pagination):
+    def feed_url(self, lane, facets, pagination):
         """Incorporate pages into filenames for static feeds
         """
         filename = self.base_filename

--- a/scripts.py
+++ b/scripts.py
@@ -314,7 +314,7 @@ class CustomOPDSFeedGenerationScript(Script):
             Facets.AVAILABLE_OPEN_ACCESS
         ],
         Facets.COLLECTION_FACET_GROUP_NAME : [
-            Facets.COLLECTION_MAIN
+            Facets.COLLECTION_FULL
         ]
     }
 
@@ -440,7 +440,7 @@ class CustomOPDSFeedGenerationScript(Script):
             feed_id, base_filename, default_order=self.DEFAULT_ORDER
         )
         static_facets = Facets(
-            Facets.COLLECTION_MAIN, Facets.AVAILABLE_OPEN_ACCESS,
+            Facets.COLLECTION_FULL, Facets.AVAILABLE_OPEN_ACCESS,
             Facets.ORDER_TITLE, enabled_facets=self.DEFAULT_ENABLED_FACETS
         )
 

--- a/scripts.py
+++ b/scripts.py
@@ -319,7 +319,7 @@ class CustomOPDSFeedGenerationScript(Script):
     }
 
     # Static feeds are refreshed each time they're created, so this
-    # type will primarily just to distinguish them in the database.
+    # type is primarily just to distinguish them in the database.
     CACHE_TYPE = 'static'
 
     @classmethod
@@ -423,7 +423,7 @@ class CustomOPDSFeedGenerationScript(Script):
             if not work:
                 detail_list += (bullet + "%r : No Work found." % license_pool)
                 continue
-            detail_list += (bullet + "%r : Unknown error.")
+            detail_list += (bullet + "%r : Unknown error." % identifier)
         self.log.warn(
             "%i identifiers could not be added to the feed. %s",
             len(missing_ids), detail_list


### PR DESCRIPTION
This branch adds pagination to static feeds, which currently means adding page links to the filenames. Filenames will look something like `<FEED-NAME>_<ORDERED-BY>_<PAGE_NUMBER>.opds`, starting numbering on the second page. So, for example, `index_author.opds` will have a next page of `index_author_2.opds`.

It also creates `IdentifiersLane`, a subclass of QueryGeneratedLane, to allow us to pass selected identifiers into the lane construct. This should be a good foundation for adding lanes to the static feeds we create.

Fixes #87.