### PR TITLE
Feedbooks import

### DIFF
--- a/feedbooks.py
+++ b/feedbooks.py
@@ -1,0 +1,83 @@
+import datetime
+import feedparser
+from nose.tools import set_trace
+from core.opds import OPDSFeed
+from core.opds_import import OPDSImporter
+from core.model import (
+    Hyperlink,
+    Resource,
+    Representation,
+)
+
+class FeedbooksOPDSImporter(OPDSImporter):
+
+    THIRTY_DAYS = datetime.timedelta(days=30)
+
+    def extract_feed_data(self, feed, feed_url=None):
+        metadata, failures = super(FeedbooksOPDSImporter, self).extract_feed_data(
+            feed, feed_url
+        )
+        for id, metadata in metadata.items():
+            self.improve_description(id, metadata)
+        return metadata, failures
+        
+    def improve_description(self, id, metadata):
+        """Improve the description associated with a book,
+        if possible.
+
+        This involves fetching an alternate OPDS entry that might
+        contain more detailed descriptions than those available in the
+        main feed.
+        """
+        alternate_links = []
+        existing_descriptions = []
+        everything_except_descriptions = []
+        for x in metadata.links:
+            if (x.rel == Hyperlink.ALTERNATE and x.href
+                and x.media_type == OPDSFeed.ENTRY_TYPE):
+                alternate_links.append(x)
+            if x.rel == Hyperlink.DESCRIPTION:
+                existing_descriptions.append((x.media_type, x.content))
+            else:
+                everything_except_descriptions.append(x)
+
+        better_descriptions = []
+        for alternate_link in alternate_links:
+            # There should only be one alternate link, but we'll keep
+            # processing them until we get a good description.
+
+            # Fetch the alternate entry.
+            representation, is_new = Representation.get(
+                self._db, alternate_link.href, max_age=self.THIRTY_DAYS
+            )
+
+            # Parse the alternate entry with feedparser and run it through
+            # data_detail_for_feedparser_entry().
+            parsed = feedparser.parse(representation.content)
+            if len(parsed['entries']) != 1:
+                # This is supposed to be a single entry, and it's not.
+                continue
+            [entry] = parsed['entries']
+            detail_id, new_detail, failure = self.data_detail_for_feedparser_entry(
+                entry, None
+            )
+
+            # TODO: Ideally we could verify that detail_id == id, but
+            # right now they are always different -- one is an HTTPS
+            # URI and one is an HTTP URI. So we omit this step and
+            # assume the 'alternate' links are correct.
+
+            # Find any descriptions present in the alternate view which
+            # are not present in the original.
+            new_descriptions = [
+                x for x in new_detail['links']
+                if x.rel == Hyperlink.DESCRIPTION
+                and (x.media_type, x.content) not in existing_descriptions
+            ]
+
+            if new_descriptions:
+                # Replace old descriptions with new descriptions.
+                metadata.links = (
+                    everything_except_descriptions + new_descriptions
+                )
+        return metadata

--- a/feedbooks.py
+++ b/feedbooks.py
@@ -7,6 +7,7 @@ from core.model import (
     Hyperlink,
     Resource,
     Representation,
+    RightsStatus,
 )
 
 class FeedbooksOPDSImporter(OPDSImporter):
@@ -20,7 +21,24 @@ class FeedbooksOPDSImporter(OPDSImporter):
         for id, metadata in metadata.items():
             self.improve_description(id, metadata)
         return metadata, failures
-        
+
+    def rights_for_entry(self, entry):
+        """Determine the URI that best encapsulates the rights status of
+        the downloads associated with this book.
+
+        Most of the time this will be CC-BY-NC, the rights status
+        associated with Feedbooks, or "full copyright", for books that
+        are redistributable in France but not in the US. In rare cases
+        it will be some other CC license that prohibits Feedbooks from
+        relicensing as CC-BY-NC.
+
+        :return: A URI.
+        """
+        rights = entry.get('rights', "")
+        source = entry.get('dcterms_source', '')
+        publication_year = entry.get('dcterms_issued', None)
+        return RehostingPolicy.rights_uri(rights, source, publication_year)
+            
     def improve_description(self, id, metadata):
         """Improve the description associated with a book,
         if possible.
@@ -81,3 +99,127 @@ class FeedbooksOPDSImporter(OPDSImporter):
                     everything_except_descriptions + new_descriptions
                 )
         return metadata
+
+
+class RehostingPolicy(object):
+    """Determining the precise copyright status of the underlying text
+    is not directly useful, because Feedbooks has made derivative
+    works and relicensed under CC-BY-NC. So that's going to be the
+    license: CC-BY-NC.
+    
+    Except it's not that simple. There are two complications.
+    
+    1. Feedbooks is located in France, and NYPL's open-access
+    content server is hosted in the US. We can't host a CC-BY-NC
+    book if it's derived from a work that's still under US
+    copyright. We must decide whether or not to accept a book in the
+    first place based on the copyright status of the underlying
+    text.
+    
+    2. Some CC licenses are more restrictive (on the creators of
+    derivative works) than CC-BY-NC. Feedbooks has no authority to
+    relicense these books, so they need to be preserved.
+
+    This class encapsulates the logic necessary to make this decision.
+    """
+    
+    PUBLIC_DOMAIN_CUTOFF = 1923    
+
+    # These are the licenses that need to be preserved.
+    RIGHTS_DICT = {    
+        "Attribution Share Alike (cc by-sa)" : RightsStatus.CC_BY_SA,
+        "Attribution Non-Commercial No Derivatives (cc by-nc-nd)" : RightsStatus.CC_BY_NC_ND,
+        "Attribution Non-Commercial Share Alike (cc by-nc-sa)" : RightsStatus.CC_BY_NC_SA,
+    }
+    
+    # Feedbooks rights statuses indicating books that can be rehosted
+    # in the US.
+    CAN_REHOST_IN_US = set([
+        "This work was published before 1923 and is in the public domain in the USA only.",
+        "This work is available for countries where copyright is Life+70 and in the USA.",
+        'This work is available for countries where copyright is Life+50 or in the USA (published before 1923).',
+        "Attribution (cc by)",
+        "Attribution Non-Commercial (cc by-nc)",
+
+        "Attribution Share Alike (cc by-sa)",
+        "Attribution Non-Commercial No Derivatives (cc by-nc-nd)",
+        "Attribution Non-Commercial Share Alike (cc by-nc-sa)",
+    ])
+
+    # These websites are hosted in the US and specialize in
+    # open-access content. We will accept all FeedBooks titles taken
+    # from these sites, even post-1923 titles.
+    US_SITES = set([
+        "archive.org",
+        "craphound.com",
+        "en.wikipedia.org",
+        "en.wikisource.org",
+        "futurismic.com",
+        "gutenberg.org",
+        "project gutenberg",
+        "shakespeare.mit.edu",
+    ])
+
+    @classmethod
+    def rights_uri(cls, rights, source, publication_year):
+        if not cls.can_rehost_us(rights, source, publication_year):
+            # We believe this book is still under copyright in the US
+            # and we should not rehost it.
+            return RightsStatus.IN_COPYRIGHT
+
+        if rights in cls.RIGHTS_DICT:
+            # The CC license of the underlying text means it cannot be
+            # relicensed CC-BY-NC.
+            return cls.RIGHTS_DICT[rights]
+
+        # The default license as per our agreement with FeedBooks.
+        return RightsStatus.CC_BY_NC
+    
+    @classmethod
+    def can_rehost_us(cls, rights, source, publication_year):
+        """Can we rehost this book on a US server?
+
+        :param rights: What FeedBooks says about the public domain status
+        of the book.
+
+        :param source: Where FeedBooks got the book.
+
+        :param publication_year: When the text was originally published.
+
+        :return: True or False
+        """
+        if publication_year < cls.PUBLIC_DOMAIN_CUTOFF:
+            # We will rehost anything published prior to 1923, no
+            # matter where it came from.
+            return True
+        
+        if rights in cls.CAN_REHOST_IN_US:
+            # This book's FeedBooks rights statement explicitly marks
+            # it as one that can be rehosted in the US.
+            return True
+            
+        # The rights statement isn't especially helpful, but maybe we
+        # can make a determination based on where Feedbooks got the
+        # book from.
+        source = (source or "").lower()
+
+        if any(site in source for site in cls.US_SITES):
+            # This book originally came from a US-hosted site that
+            # specializes in open-access books, so we must be able
+            # to rehost it.
+            return True
+
+        if source in ('wikisource', 'gutenberg'):
+            # Presumably en.wikisource and Project Gutenberg US.  We
+            # special case these to avoid confusing the US versions of
+            # these sites with other countries'.
+            return True
+                
+        # And we special-case this one to avoid confusing Australian
+        # Project Gutenberg with US Project Gutenberg.
+        if ('gutenberg.net' in source and not 'gutenberg.net.au' in source):
+            return True
+
+        # Unless one of the above conditions is met, we must assume
+        # the book cannot be rehosted in the US.
+        return False

--- a/feedbooks.py
+++ b/feedbooks.py
@@ -25,8 +25,8 @@ class FeedbooksOPDSImporter(OPDSImporter):
         metadata, failures = super(FeedbooksOPDSImporter, self).extract_feed_data(
             feed, feed_url
         )
-        for id, metadata in metadata.items():
-            self.improve_description(id, metadata)
+        for id, m in metadata.items():
+            self.improve_description(id, m)
         return metadata, failures
 
     def rights_for_entry(self, entry):

--- a/tests/files/feedbooks/677.atom
+++ b/tests/files/feedbooks/677.atom
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:dcterms="http://purl.org/dc/terms/" xmlns:schema="http://schema.org/" xmlns="http://www.w3.org/2005/Atom" xmlns:thr="http://purl.org/syndication/thread/1.0">
+<title>Discourse on the Method</title>
+<id>http://www.feedbooks.com/book/677</id>
+<author>
+  <name>Ren&#233; Descartes</name>
+  <uri>http://www.feedbooks.com/author/143</uri>
+</author>
+<published>2007-03-15T18:27:01Z</published>
+<updated>2015-04-07T09:16:25Z</updated>
+<dcterms:language>en</dcterms:language>
+<dcterms:issued>1637</dcterms:issued>
+<category scheme="http://www.feedbooks.com/categories" label="Non-Fiction" term="FBNFC000000"/>
+<category scheme="http://www.feedbooks.com/categories" label="Human Science" term="FSHUM000000N"/>
+<category scheme="http://www.feedbooks.com/categories" label="Philosophy" term="FBPHI000000"/>
+<summary>The Discourse on the Method is a philosophical and mathematical treatise published by Ren&#233; Descartes in 1637. Its full name is Discourse on the Method of Rightly Conducting the Reason, and Searching for Truth in the Sciences (French title: Discour...</summary>
+<dcterms:extent>23,005 words</dcterms:extent>
+<dcterms:source>http://en.wikisource.org</dcterms:source>
+<link type="text/html" href="http://www.feedbooks.com/book/677" rel="alternate" title="View on Feedbooks"/>
+<link type="application/epub+zip" href="http://www.feedbooks.com/book/677.epub" rel="http://opds-spec.org/acquisition"/>
+<link type="application/x-mobipocket-ebook" href="http://www.feedbooks.com/book/677.mobi" rel="http://opds-spec.org/acquisition"/>
+<link type="application/pdf" href="http://www.feedbooks.com/book/677.pdf" rel="http://opds-spec.org/acquisition"/>
+<link type="image/jpeg" href="http://covers.feedbooks.net/book/677.jpg?size=large&amp;t=1428398185" rel="http://opds-spec.org/image"/>
+<link type="image/jpeg" href="http://covers.feedbooks.net/book/677.jpg?t=1428398185" rel="http://opds-spec.org/image/thumbnail"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="http://www.feedbooks.com/author/143/books/top.atom?lang=en" rel="http://www.feedbooks.com/opds/same_author" title="From the same author"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=navigation" href="http://www.feedbooks.com/book/677/categories.atom" rel="related" title="Categories for this book"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=navigation" href="http://www.feedbooks.com/book/677/lists.atom" rel="related" title="Reading lists for this book"/>
+<link type="application/atom+xml" href="http://www.feedbooks.com/book/677/comments.atom" thr:count="0" rel="replies" thr:updated="2009-08-18T01:17:10Z" title="Comments for this book (0)"/>
+<content type="html">&lt;p&gt;The Discourse on the Method is a philosophical and mathematical treatise published by Ren&#233; Descartes in 1637. Its full name is Discourse on the Method of Rightly Conducting the Reason, and Searching for Truth in the Sciences (French title: Discours de la m&#233;thode pour bien conduire sa raison, et chercher la verit&#233; dans les sciences). The Discourse on Method is best known as the source of the famous quotation &quot;Je pense, donc je suis&quot; (&quot;I think, therefore I am&quot;), which occurs in Part IV of the work. (The similar statement in Latin, Cogito ergo sum, is found in &#167;7 of Principles of Philosophy.) In addition, in one of its appendices, La G&#233;om&#233;trie, is contained Descartes' first introduction of the Cartesian coordinate system.
+&lt;br /&gt;The Discourse on the Method is one of the most influential works in the history of modern science. It is a method which gives a solid platform from which all modern natural sciences could evolve. In this work, Descartes tackles the problem of skepticism which had been revived from the ancients such as Sextus Empiricus by authors such as Al-Ghazali and Michel de Montaigne. Descartes modified it to account for a truth that he found to be incontrovertible. Descartes started his line of reasoning by doubting everything, so as to assess the world from a fresh perspective, clear of any preconceived notions.
+&lt;br /&gt;The book was originally published in Leiden in French, together with his works &quot;Dioptrique, M&#233;t&#233;ores et G&#233;om&#233;trie&quot;. Later, it was translated into Latin and published in 1656 in Amsterdam.
+&lt;br /&gt;Together with Meditations on First Philosophy (Meditationes de Prima Philosophia), Principles of Philosophy (Principia philosophiae) and Rules for the Direction of the Mind (Regulae ad directionem ingenii), it forms the base of the Epistemology known as Cartesianism.&lt;/p&gt;</content>
+<link type="application/atom+xml;type=entry;profile=opds-catalog" href="http://www.feedbooks.com/book/677.atom" rel="self"/>
+  <link type="application/atom+xml" href="http://www.feedbooks.com/book/677/contents.atom" rel="contents"/>
+</entry>

--- a/tests/files/feedbooks/feed.atom
+++ b/tests/files/feedbooks/feed.atom
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:schema="http://schema.org" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:app="http://www.w3.org/2007/app" xml:lang="en" xmlns:odl="http://opds-spec.org/odl" xmlns="http://www.w3.org/2005/Atom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thr="http://purl.org/syndication/thread/1.0" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+  <id>http://www.feedbooks.com/books/top.atom?category=FSHUM000000N&amp;amp;lang=en</id>
+  <title>Human Science</title>
+  <updated>2016-11-08T21:11:13Z</updated>
+  <icon>http://assets2.feedbooks.net/images/favicon.ico?t=1478624086</icon>
+  <author>
+    <name>Feedbooks</name>
+    <uri>http://www.feedbooks.com</uri>
+    <email>support@feedbooks.zendesk.com</email>
+  </author>
+  <link type="application/atom+xml; profile=opds-catalog; kind=acquisition" href="http://www.feedbooks.com/books/top.atom?category=FSHUM000000N&amp;amp;lang=en" rel="self" title="Most Popular"/>
+  <link type="application/atom+xml;profile=opds-catalog;kind=navigation" href="http://www.feedbooks.com/catalog.atom" rel="start" title="Home"/>
+  <link type="application/opensearchdescription+xml" href="http://www.feedbooks.com/opensearch.xml" rel="search" title="Search on Feedbooks"/>
+  <link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="https://www.feedbooks.com/user/bookshelf.atom" rel="http://opds-spec.org/shelf" title="Bookshelf"/>
+<opensearch:totalResults>55</opensearch:totalResults>
+<opensearch:itemsPerPage>50</opensearch:itemsPerPage>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="http://www.feedbooks.com/books/top.atom?category=FSHUM000000N&amp;lang=en&amp;page=2" rel="next" title="Next Page"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="http://www.feedbooks.com/books/recent.atom?category=FSHUM000000N&amp;lang=en" rel="http://opds-spec.org/sort/new" title="Recently Added"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="/books/top.atom?category=FBPHI000000&amp;free=true&amp;lang=en" opds:facetGroup="In category" rel="http://opds-spec.org/facet" title="Philosophy" thr:count="50"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="/books/top.atom?category=FBLAN000000&amp;free=true&amp;lang=en" opds:facetGroup="In category" rel="http://opds-spec.org/facet" title="Language arts &amp; disciplines" thr:count="3"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="/books/top.atom?category=FBPSY000000&amp;free=true&amp;lang=en" opds:facetGroup="In category" rel="http://opds-spec.org/facet" title="Psychology" thr:count="3"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="/books/top.atom?category=FSHUM000000N&amp;free=true&amp;lang=en" opds:facetGroup="Language" rel="http://opds-spec.org/facet" opds:activeFacet="true" title="English" thr:count="55"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="/books/top.atom?category=FSHUM000000N&amp;free=true&amp;lang=fr" opds:facetGroup="Language" rel="http://opds-spec.org/facet" title="French" thr:count="23"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="/books/top.atom?category=FSHUM000000N&amp;free=true&amp;lang=de" opds:facetGroup="Language" rel="http://opds-spec.org/facet" title="German" thr:count="10"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="/books/top.atom?category=FSHUM000000N&amp;free=true&amp;lang=es" opds:facetGroup="Language" rel="http://opds-spec.org/facet" title="Spanish" thr:count="11"/>
+<link type="application/atom+xml;profile=opds-catalog;kind=acquisition" href="/books/top.atom?category=FSHUM000000N&amp;free=true&amp;lang=it" opds:facetGroup="Language" rel="http://opds-spec.org/facet" title="Italian" thr:count="16"/>
+<entry>
+<title>Discourse on the Method</title>
+<id>http://www.feedbooks.com/book/677</id>
+<author>
+  <name>Ren&#233; Descartes</name>
+  <uri>http://www.feedbooks.com/author/143</uri>
+</author>
+<published>2007-03-15T18:27:01Z</published>
+<updated>2015-04-07T09:16:25Z</updated>
+<dcterms:language>en</dcterms:language>
+<dcterms:issued>1637</dcterms:issued>
+<category scheme="http://www.feedbooks.com/categories" term="FBNFC000000" label="Non-Fiction"/>
+<category scheme="http://www.feedbooks.com/categories" term="FSHUM000000N" label="Human Science"/>
+<category scheme="http://www.feedbooks.com/categories" term="FBPHI000000" label="Philosophy"/>
+<summary>The Discourse on the Method is a philosophical and mathematical treatise published by Ren&#233; Descartes in 1637. Its full name is Discourse on the Method of Rightly Conducting the Reason, and Searching for Truth in the Sciences (French title: Discour...</summary>
+<dcterms:extent>23,005 words</dcterms:extent>
+<dcterms:source>http://en.wikisource.org</dcterms:source>
+<link type="text/html" href="http://www.feedbooks.com/book/677" rel="alternate" title="View on Feedbooks"/>
+<link type="application/epub+zip" href="http://www.feedbooks.com/book/677.epub" rel="http://opds-spec.org/acquisition"/>
+<link type="application/x-mobipocket-ebook" href="http://www.feedbooks.com/book/677.mobi" rel="http://opds-spec.org/acquisition"/>
+<link type="application/pdf" href="http://www.feedbooks.com/book/677.pdf" rel="http://opds-spec.org/acquisition"/>
+<link type="image/jpeg" href="http://covers.feedbooks.net/book/677.jpg?size=large&amp;t=1428398185" rel="http://opds-spec.org/image"/>
+<link type="image/jpeg" href="http://covers.feedbooks.net/book/677.jpg?t=1428398185" rel="http://opds-spec.org/image/thumbnail"/>
+<link type="application/atom+xml;type=entry;profile=opds-catalog" href="http://www.feedbooks.com/book/677.atom" rel="alternate" title="Full entry"/>
+</entry>
+</feed>

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -59,12 +59,12 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         )
         [(key, value)] = metadata.items()
         eq_(u'http://www.feedbooks.com/book/677', key)
-        eq_("Discourse on the method", value.title)
+        eq_("Discourse on the Method", value.title)
 
         # Instead of the short description from feed.atom, we have the
         # long description from 677.atom.
         [description] = [x for x in value.links if x.rel==Hyperlink.DESCRIPTION]
-        eq_(1818, len(description.content)
+        eq_(1818, len(description.content))
         
     def test_improve_description(self):
         # Here's a Metadata that has a bad (truncated) description.

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -1,0 +1,198 @@
+import os
+from nose.tools import (
+    eq_,
+    set_trace,
+)
+from . import DatabaseTest
+from ..feedbooks import (
+    FeedbooksOPDSImporter,
+    RehostingPolicy,
+)
+from ..core.model import (
+    DataSource,
+    Hyperlink,
+    RightsStatus
+)
+from ..core.metadata_layer import (
+    Metadata,
+    LinkData,
+)
+from ..core.opds import OPDSFeed
+from ..core.s3 import DummyS3Uploader
+from ..core.testing import DummyHTTPClient
+
+LIFE_PLUS_70 = "This work is available for countries where copyright is Life+70."
+
+class TestFeedbooksOPDSImporter(DatabaseTest):
+
+    def setup(self):
+        super(TestFeedbooksOPDSImporter, self).setup()
+        self.http = DummyHTTPClient()
+        self.importer = FeedbooksOPDSImporter(
+            self._db, http_get = self.http.do_get
+        )
+        self.data_source = DataSource.lookup(
+            self._db, self.importer.DATA_SOURCE_NAME, autocreate=True
+        )
+        
+        base_path = os.path.split(__file__)[0]
+        self.resource_path = os.path.join(base_path, "files", "feedbooks")
+
+    def sample_file(self, filename):
+        path = os.path.join(self.resource_path, filename)
+        data = open(path).read()
+        return data
+
+    def test_rights_for_entry(self):
+        entry = dict(rights=LIFE_PLUS_70,
+                     source='gutenberg.net.au',
+                     publication_year="1922")
+        rights = self.importer.rights_for_entry(entry) 
+        eq_(RightsStatus.CC_BY_NC, rights)
+
+    def test_extract_feed_data_improves_descriptions(self):
+        feed = self.sample_file("feed.atom")
+        self.http.queue_response(200, OPDSFeed.ENTRY_TYPE,
+                                 content=self.sample_file("677.atom"))
+        metadata, failures = self.importer.extract_feed_data(
+            feed, "http://url/"
+        )
+        [(key, value)] = metadata.items()
+        eq_(u'http://www.feedbooks.com/book/677', key)
+        eq_("Discourse on the method", value.title)
+
+        # Instead of the short description from feed.atom, we have the
+        # long description from 677.atom.
+        [description] = [x for x in value.links if x.rel==Hyperlink.DESCRIPTION]
+        eq_(1818, len(description.content)
+        
+    def test_improve_description(self):
+        # Here's a Metadata that has a bad (truncated) description.
+        metadata = Metadata(self.data_source)
+
+        bad_description = LinkData(rel=Hyperlink.DESCRIPTION, media_type="text/plain", content=u"The Discourse on the Method is a philosophical and mathematical treatise published by Ren\xe9 Descartes in 1637. Its full name is Discourse on the Method of Rightly Conducting the Reason, and Searching for Truth in the Sciences (French title: Discour...")
+
+        irrelevant_description = LinkData(
+            rel=Hyperlink.DESCRIPTION, media_type="text/plain",
+            content="Don't look at me; I'm irrelevant!"
+        )
+        
+        # Sending an HTTP request to this URL is going to give a 404 error.
+        alternate = LinkData(rel=Hyperlink.ALTERNATE, href="http://foo/",
+                             media_type=OPDSFeed.ENTRY_TYPE)
+
+        # We're not even going to try to send an HTTP request to this URL
+        # because it doesn't promise an OPDS entry.
+        alternate2 = LinkData(rel=Hyperlink.ALTERNATE, href="http://bar/",
+                             media_type="text/html")
+        
+        # But this URL will give us full information about this
+        # entry, including a better description.
+        alternate3 = LinkData(
+            rel=Hyperlink.ALTERNATE, href="http://baz/",
+            media_type=OPDSFeed.ENTRY_TYPE
+        )
+
+        # This URL will not be requested because the third alternate URL
+        # gives us the answer we're looking for.
+        alternate4 = LinkData(
+            rel=Hyperlink.ALTERNATE, href="http://qux/",
+            media_type=OPDSFeed.ENTRY_TYPE
+        )
+        
+        # Two requests will be made. The first will result in a 404
+        # error. The second will give us an OPDS entry.
+        self.http.queue_response(200, OPDSFeed.ENTRY_TYPE,
+                                 content=self.sample_file("677.atom"))
+        self.http.queue_response(404, content="Not found")
+        
+        metadata.links = [bad_description, irrelevant_description,
+                          alternate, alternate2, alternate3, alternate4]
+
+        self.importer.improve_description("some ID", metadata)
+
+        # The descriptions have been removed from metatadata.links,
+        # because 677.atom included a description we know was better.
+        #
+        # The incomplete description was removed even though 677.atom
+        # also included a copy of it.
+        assert bad_description not in metadata.links
+        assert irrelevant_description not in metadata.links
+        
+        # The more complete description from 677.atom has been added.
+        [good_description] = [
+            x for x in metadata.links if x.rel == Hyperlink.DESCRIPTION
+        ]
+        
+        # The four alternate links have not been touched.
+        assert (alternate in metadata.links)
+        assert (alternate2 in metadata.links)
+        assert (alternate3 in metadata.links)
+        assert (alternate4 in metadata.links)
+
+        # Two HTTP requests were made.
+        eq_(['http://foo/', 'http://baz/'], self.http.requests)
+        
+class TestRehostingPolicy(object):
+    
+    def test_rights_uri(self):
+        # A Feedbooks work based on a text that is in copyright in the
+        # US gets a RightsStatus of IN_COPYRIGHT.  We will not be
+        # hosting this book and if we should host it by accident we
+        # will not redistribute it.
+        pd_in_australia_only = RehostingPolicy.rights_uri(
+            LIFE_PLUS_70, "gutenberg.net.au", 1930
+        )
+        eq_(RightsStatus.IN_COPYRIGHT, pd_in_australia_only)
+
+        # A Feedbooks work based on a text that is in the US public
+        # domain is relicensed to us as CC-BY-NC.
+        pd_in_us = RehostingPolicy.rights_uri(
+            LIFE_PLUS_70, "gutenberg.net.au", 1922
+        )
+        eq_(RightsStatus.CC_BY_NC, pd_in_us)
+
+        # A Feedbooks work based on a text whose CC license is not
+        # compatible with CC-BY-NC is relicensed to us under the
+        # original license.
+        sharealike = RehostingPolicy.rights_uri(
+            "Attribution Share Alike (cc by-sa)", "mywebsite.com", 2016
+        )
+        eq_(RightsStatus.CC_BY_SA, sharealike)
+
+    def test_can_rehost_us(self):
+        # We will rehost anything published prior to 1923.
+        eq_(
+            True, RehostingPolicy.can_rehost_us(
+                LIFE_PLUS_70, "gutenberg.net.au", 1922
+            )
+        )
+
+        # We will rehost anything whose rights statement explicitly
+        # indicates it can be rehosted in the US, no matter the
+        # issuance date.
+        for terms in RehostingPolicy.CAN_REHOST_IN_US:
+            eq_(
+                True, RehostingPolicy.can_rehost_us(
+                    terms, "gutenberg.net.au", 2016
+                )
+            )
+
+        # We will rehost anything that originally derives from a
+        # US-based site that specializes in open-access books.
+        for site in list(RehostingPolicy.US_SITES) + [
+                "WikiSource", "Gutenberg", "http://gutenberg.net/"
+        ]:
+            eq_(
+                True, RehostingPolicy.can_rehost_us(
+                    None, site, 2016
+                )
+            )
+            
+        # If none of these conditions are met we will not rehost a
+        # book.
+        eq_(
+            False, RehostingPolicy.can_rehost_us(
+                LIFE_PLUS_70, "gutenberg.net.au", 1930
+            )
+        )


### PR DESCRIPTION
This branch introduces a special OPDSImporter subclass for use in importing open-access books from FeedBooks. There are two specializations of the generic OPDSImporter here. 

First, FeedBooks doesn't include a full description in the OPDS feed. To get a full description of a book you have to fetch the rel="alternate" link. This OPDSImporter automatically fetches the rel="alternate" link and replaces the incomplete descriptions with a full description.

Second, FeedBooks is hosted in France and includes titles that are not public domain in the US. The `RehostingPolicy` class encapsulates the logic necessary to determine whether we can rehost a FeedBooks title.

This is an interim branch; I have not tried to use it to actually import books from FeedBooks.