### PR TITLE
Full feedbooks import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
 
 install:
   - pip install -r requirements.txt
+  - python -m textblob.download_corpora
   - cp config.json.sample config.json
   - export SIMPLIFIED_CONFIGURATION_FILE="$TRAVIS_BUILD_DIR/config.json"
 

--- a/feedbooks.py
+++ b/feedbooks.py
@@ -27,7 +27,6 @@ class FeedbooksOPDSImporter(OPDSImporterWithS3Mirror):
         )
         for id, m in metadata.items():
             self.improve_description(id, m)
-            set_trace()
         return metadata, failures
 
     def rights_for_entry(self, entry):

--- a/feedbooks.py
+++ b/feedbooks.py
@@ -113,10 +113,6 @@ class FeedbooksOPDSImporter(OPDSImporterWithS3Mirror):
                 alternate_links.append(x)
             if x.rel == Hyperlink.DESCRIPTION:
                 existing_descriptions.append((x.media_type, x.content))
-            elif x.rel == Hyperlink.GENERIC_OPDS_ACQUISITION:
-                # This feed contains open-access links
-                # coded as generic acquisition links.
-                x.rel = Hyperlink.OPEN_ACCESS_DOWNLOAD
             else:
                 everything_except_descriptions.append(x)
 

--- a/feedbooks.py
+++ b/feedbooks.py
@@ -20,10 +20,11 @@ class FeedbooksOPDSImporter(OPDSImporterWithS3Mirror):
     THIRTY_DAYS = datetime.timedelta(days=30)
 
     def __init__(self, _db, *args, **kwargs):
+        kwargs['data_source_offers_licenses'] = True
         super(FeedbooksOPDSImporter, self).__init__(
             _db, self.DATA_SOURCE_NAME, *args, **kwargs
         )
-    
+
     def extract_feed_data(self, feed, feed_url=None):
         metadata, failures = super(FeedbooksOPDSImporter, self).extract_feed_data(
             feed, feed_url
@@ -132,10 +133,7 @@ class FeedbooksOPDSImporter(OPDSImporterWithS3Mirror):
                 # This is supposed to be a single entry, and it's not.
                 continue
             [entry] = parsed['entries']
-            data_source = DataSource.lookup(
-                self._db, self.data_source_name, autocreate=True,
-                offers_licenses=True
-            )
+            data_source = self.data_source
             detail_id, new_detail, failure = self.data_detail_for_feedparser_entry(
                 entry, data_source
             )

--- a/feedbooks.py
+++ b/feedbooks.py
@@ -75,9 +75,8 @@ class FeedbooksOPDSImporter(OPDSImporterWithS3Mirror):
         rights_uri = cls.rights_uri_from_entry_tag(entry_tag)
         circulation = feedparser_detail.setdefault('circulation', {})
         circulation['default_rights_uri'] = rights_uri            
-        return OPDSImporterWithS3Mirror._detail_for_elementtree_entry(
-            cls, parser, entry_tag, feed_url,
-            feedparser_detail
+        return super(FeedbooksOPDSImporter, cls)._detail_for_elementtree_entry(
+            parser, entry_tag, feed_url, feedparser_detail
         )
     
     @classmethod
@@ -93,7 +92,7 @@ class FeedbooksOPDSImporter(OPDSImporterWithS3Mirror):
         """
         if rel==Hyperlink.GENERIC_OPDS_ACQUISITION and media_type:
             rel = Hyperlink.OPEN_ACCESS_DOWNLOAD
-        return OPDSImporterWithS3Mirror.make_link_data(
+        return super(FeedbooksOPDSImporter, cls).make_link_data(
             rel, href, media_type, rights_uri, content
         )
     

--- a/tests/files/feedbooks/feed_with_in_copyright_book.atom
+++ b/tests/files/feedbooks/feed_with_in_copyright_book.atom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:schema="http://schema.org" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:app="http://www.w3.org/2007/app" xml:lang="en" xmlns:odl="http://opds-spec.org/odl" xmlns="http://www.w3.org/2005/Atom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thr="http://purl.org/syndication/thread/1.0" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+  <id>http://www.feedbooks.com/books/top.atom?category=FSHUM000000N&amp;amp;lang=en</id>
+  <title>Human Science</title>
+  <updated>2016-11-08T21:11:13Z</updated>
+<entry>
+<title>Discourse on the Method</title>
+<id>http://www.feedbooks.com/book/677</id>
+<author>
+  <name>Ren&#233; Descartes</name>
+  <uri>http://www.feedbooks.com/author/143</uri>
+</author>
+<published>2007-03-15T18:27:01Z</published>
+<updated>2015-04-07T09:16:25Z</updated>
+<dcterms:language>en</dcterms:language>
+<category scheme="http://www.feedbooks.com/categories" term="FBNFC000000" label="Non-Fiction"/>
+<category scheme="http://www.feedbooks.com/categories" term="FSHUM000000N" label="Human Science"/>
+<category scheme="http://www.feedbooks.com/categories" term="FBPHI000000" label="Philosophy"/>
+<summary>The Discourse on the Method is a philosophical and mathematical treatise published by Ren&#233; Descartes in 1637. Its full name is Discourse on the Method of Rightly Conducting the Reason, and Searching for Truth in the Sciences (French title: Discour...</summary>
+<dcterms:issued>1990</dcterms:issued>
+<rights>This work is available for countries where copyright is Life+70.</rights>
+<dcterms:source>gutenberg.net.au</dcterms:source>
+<link type="application/epub+zip" href="http://www.feedbooks.com/book/677.epub" rel="http://opds-spec.org/acquisition"/>
+<link type="application/x-mobipocket-ebook" href="http://www.feedbooks.com/book/677.mobi" rel="http://opds-spec.org/acquisition"/>
+<link type="application/pdf" href="http://www.feedbooks.com/book/677.pdf" rel="http://opds-spec.org/acquisition"/>
+<link type="image/jpeg" href="http://covers.feedbooks.net/book/677.jpg?size=large&amp;t=1428398185" rel="http://opds-spec.org/image"/>
+<link type="image/jpeg" href="http://covers.feedbooks.net/book/677.jpg?t=1428398185" rel="http://opds-spec.org/image/thumbnail"/>
+</entry>
+</feed>

--- a/tests/files/feedbooks/feed_with_open_access_book.atom
+++ b/tests/files/feedbooks/feed_with_open_access_book.atom
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns:schema="http://schema.org" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:app="http://www.w3.org/2007/app" xml:lang="en" xmlns:odl="http://opds-spec.org/odl" xmlns="http://www.w3.org/2005/Atom" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:thr="http://purl.org/syndication/thread/1.0" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+  <id>http://www.feedbooks.com/books/top.atom?category=FSHUM000000N&amp;amp;lang=en</id>
+  <title>Human Science</title>
+  <updated>2016-11-08T21:11:13Z</updated>
+<entry>
+<title>Discourse on the Method</title>
+<id>http://www.feedbooks.com/book/677</id>
+<author>
+  <name>Ren&#233; Descartes</name>
+  <uri>http://www.feedbooks.com/author/143</uri>
+</author>
+<published>2007-03-15T18:27:01Z</published>
+<updated>2015-04-07T09:16:25Z</updated>
+<dcterms:language>en</dcterms:language>
+<category scheme="http://www.feedbooks.com/categories" term="FBNFC000000" label="Non-Fiction"/>
+<category scheme="http://www.feedbooks.com/categories" term="FSHUM000000N" label="Human Science"/>
+<category scheme="http://www.feedbooks.com/categories" term="FBPHI000000" label="Philosophy"/>
+<summary>The Discourse on the Method is a philosophical and mathematical treatise published by Ren&#233; Descartes in 1637. Its full name is Discourse on the Method of Rightly Conducting the Reason, and Searching for Truth in the Sciences (French title: Discour...</summary>
+<dcterms:issued>1922</dcterms:issued>
+<rights>This work is available for countries where copyright is Life+70 and in the USA.</rights>
+<dcterms:source>gutenberg.net.au</dcterms:source>
+<link type="application/epub+zip" href="http://www.feedbooks.com/book/677.epub" rel="http://opds-spec.org/acquisition"/>
+<link type="application/x-mobipocket-ebook" href="http://www.feedbooks.com/book/677.mobi" rel="http://opds-spec.org/acquisition"/>
+<link type="application/pdf" href="http://www.feedbooks.com/book/677.pdf" rel="http://opds-spec.org/acquisition"/>
+<link type="image/jpeg" href="http://covers.feedbooks.net/book/677.jpg?size=large&amp;t=1428398185" rel="http://opds-spec.org/image"/>
+<link type="image/jpeg" href="http://covers.feedbooks.net/book/677.jpg?t=1428398185" rel="http://opds-spec.org/image/thumbnail"/>
+</entry>
+</feed>

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -53,15 +53,6 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         data = open(path).read()
         return data
 
-    def test_rights_uri_from_feedparser_entry(self):
-        entry = dict(rights=LIFE_PLUS_70,
-                     source='gutenberg.net.au')
-        expect = RehostingPolicy.rights_uri(
-            LIFE_PLUS_70, 'gutenberg.net.au', None
-        )
-        actual = self.importer.rights_uri_from_feedparser_entry(entry) 
-        eq_(expect, actual)
-
     def test_extract_feed_data_improves_descriptions(self):
         feed = self.sample_file("feed.atom")
         self.http.queue_response(200, OPDSFeed.ENTRY_TYPE,

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -53,12 +53,14 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         data = open(path).read()
         return data
 
-    def test_rights_for_entry(self):
+    def test_rights_uri_from_feedparser_entry(self):
         entry = dict(rights=LIFE_PLUS_70,
-                     source='gutenberg.net.au',
-                     publication_year="1922")
-        rights = self.importer.rights_for_entry(entry) 
-        eq_(RightsStatus.CC_BY_NC, rights)
+                     source='gutenberg.net.au')
+        expect = RehostingPolicy.rights_uri(
+            LIFE_PLUS_70, 'gutenberg.net.au', None
+        )
+        actual = self.importer.rights_uri_from_feedparser_entry(entry) 
+        eq_(expect, actual)
 
     def test_extract_feed_data_improves_descriptions(self):
         feed = self.sample_file("feed.atom")
@@ -245,6 +247,11 @@ class TestRehostingPolicy(object):
         )
         eq_(RightsStatus.IN_COPYRIGHT, pd_in_australia_only)
 
+        unknown_australia_publication = RehostingPolicy.rights_uri(
+            LIFE_PLUS_70, "gutenberg.net.au", None
+        )
+        eq_(RightsStatus.IN_COPYRIGHT, unknown_australia_publication)
+        
         # A Feedbooks work based on a text that is in the US public
         # domain is relicensed to us as CC-BY-NC.
         pd_in_us = RehostingPolicy.rights_uri(

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -201,7 +201,7 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
             self.http.requests
         )
 
-        # Three 'books' were uploaded to the mock S3
+        # Three 'books' were uploaded to the mock S3 service.
         eq_(['http://s3.amazonaws.com/test.content.bucket/FeedBooks/URI/http%3A//www.feedbooks.com/book/677/Discourse%20on%20the%20Method.' + extension
              for extension in 'epub', 'mobi', 'pdf'
         ],
@@ -213,6 +213,11 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
             [x.delivery_mechanism.content_type
              for x in pool.delivery_mechanisms]
         )            
+
+        # From information contained in the OPDS entry we determined
+        # all three links to be CC-BY-NC.
+        eq_([u'https://creativecommons.org/licenses/by-nc/4.0'] * 3,
+            [x.rights_status.uri for x in pool.delivery_mechanisms])
         
     def test_in_copyright_book_not_mirrored(self):
 
@@ -222,10 +227,12 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
             content=feed
         )
 
-        results = self.importer.import_from_feed(
+        [edition], [pool], [work], failures = self.importer.import_from_feed(
             feed, immediately_presentation_ready=True,
         )
-
+        set_trace()
+        pass
+        
 class TestRehostingPolicy(object):
     
     def test_rights_uri(self):

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -146,6 +146,10 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         eq_(['http://foo/', 'http://baz/'], self.http.requests)
 
     def test_generic_acquisition_link_picked_up_as_open_access(self):
+        """The OPDS feed has links with generic OPDS "acquisition"
+        relations. We know that these should be open-access relations,
+        and we modify the relations on the way in.
+        """
         feed = self.sample_file("feed_with_open_access_book.atom")
         imports, errors = self.importer.extract_feed_data(feed)
         [book] = imports.values()
@@ -220,6 +224,9 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         # all three links to be CC-BY-NC.
         eq_([u'https://creativecommons.org/licenses/by-nc/4.0'] * 3,
             [x.rights_status.uri for x in pool.delivery_mechanisms])
+
+        # The pool is marked as open-access.
+        eq_(True, pool.open_access)
         
     def test_in_copyright_book_not_mirrored(self):
 
@@ -265,8 +272,8 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         # has open-access links, they're not licensed under terms we
         # can use.
         eq_(False, pool.open_access)
-        pass
-        
+
+
 class TestRehostingPolicy(object):
     
     def test_rights_uri(self):

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -237,6 +237,11 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
             content=feed
         )
 
+        response = self.importer.import_from_feed(
+            feed, immediately_presentation_ready=True,
+        )
+        eq_([], response)
+        
         [edition], [pool], [work], failures = self.importer.import_from_feed(
             feed, immediately_presentation_ready=True,
         )

--- a/tests/test_feedbooks.py
+++ b/tests/test_feedbooks.py
@@ -240,8 +240,7 @@ class TestFeedbooksOPDSImporter(DatabaseTest):
         response = self.importer.import_from_feed(
             feed, immediately_presentation_ready=True,
         )
-        eq_([], response)
-        
+
         [edition], [pool], [work], failures = self.importer.import_from_feed(
             feed, immediately_presentation_ready=True,
         )


### PR DESCRIPTION
This branch adds specialization code to handle an OPDS import from Feedbooks's idiosyncratic OPDS feed. I have not done a full test of the Feedbooks monitor but I can correctly import records for individual books, whether they are redistributable in the US (in which case we mirror them) or not (in which case we don't mirror them).

There are two main problems that I solve:

* Feedbooks has open-access links with rel="http://opds-spec.org/acquisition". Vanilla OPDS importer ignores these links, so we modify the LinkData objects in place to have the correct link relation.

* It's impossible to determine the rights status of a book until we're deep in the Elementtree code, but the default rights status for the entry is fetched earlier on, in the Feedparser code. I have the feedparser code decline to provide a value, so that the elementtree code can come in later and fill in the value.

I also changed `can_rehost_us` slightly to return None in cases where we just don't know (without manual effort) whether we can rehost a book.