### PR TITLE
Create static youth lane

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -272,7 +272,7 @@ class StaticCOPPANavigationFeed(OPDSFeed):
             term=audience, label=audience, scheme='%saudience' % cls.SCHEMA_NS
         )
 
-    def __init__(self, title, base_url, full_lane, youth_lane):
+    def __init__(self, title, base_url, youth_lane, full_lane):
         """Turn a list of lanes into a feed."""
         annotator = StaticFeedCOPPAAnnotator(base_url)
         lane_url = annotator.default_lane_url()

--- a/opds.py
+++ b/opds.py
@@ -119,6 +119,9 @@ class StaticFeedAnnotator(ContentServerAnnotator):
             # This is the home lane.
             return cls.HOME_FILENAME
 
+        if not lane.parent:
+            return cls.slugify_feed_title(lane.name)
+
         path = list()
         while lane.parent:
             path.insert(0, cls.slugify_feed_title(lane.name))

--- a/scripts.py
+++ b/scripts.py
@@ -58,7 +58,12 @@ from lanes import (
 )
 from marc import MARCExtractor
 from monitor import GutenbergMonitor
-from opds import StaticFeedAnnotator, ContentServerAnnotator
+from opds import (
+    ContentServerAnnotator,
+    StaticFeedAnnotator,
+    StaticFeedCOPPAAnnotator,
+    StaticCOPPANavigationFeed,
+)
 from s3 import S3Uploader
 
 
@@ -633,9 +638,6 @@ class StaticFeedCSVExportScript(StaticFeedScript):
 
 class StaticFeedGenerationScript(StaticFeedScript):
 
-    # Feeds ordered by this facet will be considered the default.
-    DEFAULT_ORDER = Facets.ORDER_TITLE
-
     DEFAULT_ENABLED_FACETS = {
         Facets.ORDER_FACET_GROUP_NAME : [
             Facets.ORDER_TITLE, Facets.ORDER_AUTHOR
@@ -699,27 +701,37 @@ class StaticFeedGenerationScript(StaticFeedScript):
         if parsed.urns:
             identifiers = [Identifier.parse_urn(self._db, unicode(urn))[0]
                            for urn in parsed.urns]
-            lane = StaticFeedBaseLane(
+            full_lane = StaticFeedBaseLane(
                 self._db, identifiers, StaticFeedAnnotator.TOP_LEVEL_LANE_NAME
             )
-            full_query = lane.works()
+            full_query = full_lane.works()
 
-            self.log_missing_identifiers(lane.identifiers, full_query)
+            self.log_missing_identifiers(full_lane.identifiers, full_query)
         else:
-            lane, full_query, youth_lane = self.make_lanes_from_csv(source_csv)
+            full_lane, full_query, youth_lane = self.make_lanes_from_csv(source_csv)
 
-        search_link = None
+        search = False
         if parsed.search_url and parsed.search_index:
-            search_link = feed_id
-            if not search_link.endswith('/'):
-                search_link += '/'
-            search_link += "search"
+            search = True
 
-        feeds = list(self.create_feeds([lane], feed_id, page_size, search_link))
-
+        feeds = list()
         if youth_lane:
-            youth_feeds = list(self.create_feeds([youth_lane], feed_id, page_size))
+            # When a youth lane exists, we create a navigation feed the
+            # assist with COPPA restrictions.
+            nav_feed = StaticCOPPANavigationFeed(
+                StaticFeedCOPPAAnnotator.TOP_LEVEL_LANE_NAME, feed_id,
+                full_lane, youth_lane
+            )
+            feeds.append((StaticFeedCOPPAAnnotator.HOME_FILENAME, [unicode(nav_feed)]))
+
+            annotator = StaticFeedCOPPAAnnotator(feed_id, youth_lane, include_search=search)
+            youth_feeds = list(self.create_feeds([youth_lane], page_size, annotator))
             feeds += youth_feeds
+        else:
+            # Without a youth feed, we don't need to create a navigation feed.
+            annotator = StaticFeedAnnotator(feed_id, full_lane, include_search=search)
+
+        feeds += list(self.create_feeds([full_lane], page_size, annotator))
 
         for base_filename, feed_pages in feeds:
             for index, page in enumerate(feed_pages):
@@ -727,12 +739,17 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 if index != 0:
                     filename += '_%i' % (index+1)
 
+                content = page
+                if not isinstance(page, unicode):
+                    # This is a CachedFeed, so extract the feed string.
+                    content = page.content
+
                 if parsed.upload:
-                    self.upload(filename, page.content, uploader=uploader)
+                    self.upload(filename, content, uploader=uploader)
                 else:
                     filename = os.path.abspath(filename + '.xml')
                     with open(filename, 'w') as f:
-                        f.write(page.content)
+                        f.write(content)
                     self.log.info("OPDS feed saved locally at %s", filename)
 
         if parsed.search_url and parsed.search_index:
@@ -831,7 +848,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
         youth_lane = None
         if all_youth:
             youth_lane = StaticFeedBaseLane(
-                self._db, all_youth, "Children's Books"
+                self._db, all_youth, u"Children's Books"
             )
 
         if not lanes:
@@ -919,7 +936,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 include_all=False,
             )
 
-    def create_feeds(self, lanes, feed_id, page_size, search_link=None):
+    def create_feeds(self, lanes, page_size, annotator):
         """Creates feeds for facets that may be required
 
         :return: A dictionary of filenames pointing to a list of CachedFeed
@@ -927,15 +944,14 @@ class StaticFeedGenerationScript(StaticFeedScript):
         """
 
         for lane in lanes:
-            annotator = StaticFeedAnnotator(
-                feed_id, lane, default_order=self.DEFAULT_ORDER, search_link=search_link
-            )
+            annotator.reset(lane)
+            filename = annotator.lane_filename(lane)
+            url = annotator.lane_url(lane)
             if lane.sublanes:
                 # This is an intermediate lane, without its own works.
                 # It needs a groups feed.
-                filename = annotator.lane_filename(lane)
                 feed = AcquisitionFeed.groups(
-                    self._db, lane.name, feed_id, lane, annotator,
+                    self._db, lane.name, url, lane, annotator,
                     cache_type=self.CACHE_TYPE,
                     force_refresh=True,
                     use_materialized_works=False
@@ -944,7 +960,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
 
                 # Return filenames and feeds for any sublanes as well.
                 for filename, feeds in self.create_feeds(
-                    lane.sublanes, feed_id, page_size, search_link=search_link
+                    lane.sublanes, page_size, annotator
                 ):
                     yield filename, feeds
             else:
@@ -960,21 +976,20 @@ class StaticFeedGenerationScript(StaticFeedScript):
 
                     pagination = Pagination(size=page_size)
                     feed_pages = self.create_feed_pages(
-                        lane, pagination, feed_id, annotator, facet_obj
+                        lane, pagination, url, annotator, facet_obj
                     )
 
-                    filename = annotator.lane_filename(lane)
-                    if ordered_by != self.DEFAULT_ORDER:
+                    if ordered_by != annotator.DEFAULT_ORDER:
                         filename += ('_' + ordered_by)
                     yield filename, feed_pages
 
-    def create_feed_pages(self, lane, pagination, feed_id, annotator, facet):
+    def create_feed_pages(self, lane, pagination, lane_url, annotator, facet):
         """Yields each page of the feed for a particular lane."""
         pages = list()
         previous_page = pagination.previous_page
         while not previous_page or previous_page.has_next_page:
             page = AcquisitionFeed.page(
-                self._db, lane.name, feed_id, lane,
+                self._db, lane.name, lane_url, lane,
                 annotator=annotator,
                 facets=facet,
                 pagination=pagination,

--- a/scripts.py
+++ b/scripts.py
@@ -718,7 +718,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
         feeds = list(self.create_feeds([lane], feed_id, page_size, search_link))
 
         if youth_lane:
-            youth_feeds = self.create_feeds([youth_lane], feed_id, page_size)
+            youth_feeds = list(self.create_feeds([youth_lane], feed_id, page_size))
             feeds += youth_feeds
 
         for base_filename, feed_pages in feeds:

--- a/scripts.py
+++ b/scripts.py
@@ -720,7 +720,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
             # assist with COPPA restrictions.
             nav_feed = StaticCOPPANavigationFeed(
                 StaticFeedCOPPAAnnotator.TOP_LEVEL_LANE_NAME, feed_id,
-                full_lane, youth_lane
+                youth_lane, full_lane
             )
             feeds.append((StaticFeedCOPPAAnnotator.HOME_FILENAME, [unicode(nav_feed)]))
 

--- a/tests/files/scripts/youth.csv
+++ b/tests/files/scripts/youth.csv
@@ -1,0 +1,8 @@
+urn,title,author,epub,youth,Fiction>General Fiction,Nonfiction,Short Stories,Fiction>Horror,Fiction>Science Fiction,Short Stories > General Fiction, Fiction > Horror > Paranormal Mystery
+urn:isbn:9781682280065,Frankenstein,Mary Shelley,http://oabooks.nypl.org/ISBN/9781682280065.epub,,,,,x,,
+urn:isbn:9781682280003,Journey to the Center of the Earth,Jules Verne,http://oabooks.nypl.org/ISBN/9781682280003.epub,,,,,,,x
+urn:isbn:9781682280010,Little Women,Louisa May Alcott,http://oabooks.nypl.org/ISBN/9781682280010.epub,x,x,,,,,
+urn:isbn:9781682280027,The Call of the Wild,Jack London,http://oabooks.nypl.org/ISBN/9781682280027.epub,x,,,,,x,
+urn:isbn:9781682280034,The Jungle,Upton Sinclair,http://oabooks.nypl.org/ISBN/9781682280034.epub,,,x,,,,
+urn:isbn:9781682280041,The Strange Case of Dr. Jekyll and Mr. Hyde,Robert Louis Stevenson,http://oabooks.nypl.org/ISBN/9781682280041.epub,,,,,x,,
+urn:isbn:9781682280058,Dracula,Bram Stoker,http://oabooks.nypl.org/ISBN/9781682280058.epub,,,,,x,,

--- a/tests/test_opds.py
+++ b/tests/test_opds.py
@@ -1,3 +1,5 @@
+import feedparser
+
 from nose.tools import (
     assert_raises,
     eq_,
@@ -7,8 +9,19 @@ from . import DatabaseTest
 from ..opds import (
     ContentServerAnnotator,
     StaticFeedAnnotator,
+    StaticCOPPANavigationFeed,
 )
 from ..core.opds import UnfulfillableWork
+
+class MockStaticLane(object):
+
+    """Empty, unobtrusive Lane class that gives any
+    StaticFeedAnnotator a name to work with."""
+
+    def __init__(self, name):
+        self.parent = None
+        self.name = name or 'Fake Lane'
+
 
 class TestAnnotator(DatabaseTest):
 
@@ -26,6 +39,7 @@ class TestAnnotator(DatabaseTest):
             None, None
         )
 
+
 class TestStaticFeedAnnotator(object):
 
     def test_slugify_feed_title(self):
@@ -33,3 +47,52 @@ class TestStaticFeedAnnotator(object):
         eq_('hey-im-a-feed', annotator.slugify_feed_title("Hey! I'm a feed!!"))
         eq_('you-and-me-n-every_feed', annotator.slugify_feed_title("You & Me n Every_Feed"))
         eq_('money-honey', annotator.slugify_feed_title("Money $$$       Honey"))
+
+
+class TestStaticCOPPANavigationFeed(object):
+
+    def test_feed(self):
+        youth_lane = MockStaticLane('For Kids')
+        adult_lane = MockStaticLane('For Adults')
+
+        feed = StaticCOPPANavigationFeed(
+            'Books', 'books.org', youth_lane, adult_lane
+        )
+
+        parsed = feedparser.parse(unicode(feed))
+
+        # The feed has the right basic information.
+        eq_('books.org/index.xml', parsed.feed.id)
+        [link] = parsed.feed.links
+        eq_('books.org/index.xml', link.href)
+        eq_('Books', parsed.feed.title)
+        assert parsed.feed.updated
+
+        entries = parsed.entries
+        eq_(2, len(entries))
+
+        # The children's feed entry has accurate details
+        kid_url = 'books.org/for-kids.xml'
+        [children] = [e for e in entries if e.id==kid_url]
+        assert "under 13" in children.title.lower()
+        assert children.updated
+
+        [content] = children.content
+        assert "children's books" in content.value.lower()
+        [link] = children.links
+        eq_(feed.ACQUISITION_FEED_TYPE, link.type)
+        eq_(kid_url, link.href)
+        eq_('subsection', link.rel)
+
+        # The adult feed entry has accurate details
+        adult_url = 'books.org/for-adults.xml'
+        [adult] = [e for e in entries if e.id==adult_url]
+        assert "13 or older" in adult.title.lower()
+        assert adult.updated
+
+        [content] = adult.content
+        assert "full collection" in content.value.lower()
+        [link] = adult.links
+        eq_(feed.ACQUISITION_FEED_TYPE, link.type)
+        eq_(adult_url, link.href)
+        eq_('subsection', link.rel)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -136,7 +136,7 @@ class TestStaticFeedGenerationScript(DatabaseTest):
         eq_(2, len(self.uploader.content))
         for feed in self.uploader.content:
             parsed = feedparser.parse(feed)
-            eq_(u'mta.librarysimplified.org', parsed.feed.id)
+            eq_(u'mta.librarysimplified.org/index.xml', parsed.feed.id)
             eq_(StaticFeedAnnotator.TOP_LEVEL_LANE_NAME, parsed.feed.title)
 
             # There are links for the different facets.
@@ -354,10 +354,9 @@ class TestStaticFeedGenerationScript(DatabaseTest):
         lane = StaticFeedBaseLane(
             self._db, identifiers, StaticFeedAnnotator.TOP_LEVEL_LANE_NAME
         )
+        annotator = StaticFeedAnnotator('https://mta.librarysimplified.org')
 
-        results = list(self.script.create_feeds(
-            [lane], 'https://mta.librarysimplified.org', 50
-        ))
+        results = list(self.script.create_feeds([lane], 50, annotator))
 
         eq_(2, len(results))
         eq_(['index', 'index_author'], sorted([r[0] for r in results]))
@@ -387,7 +386,7 @@ class TestStaticFeedGenerationScript(DatabaseTest):
         lane = StaticFeedBaseLane(
             self._db, identifiers, StaticFeedAnnotator.TOP_LEVEL_LANE_NAME
         )
-        facet = Facets('main', 'always', 'title')
+        facet = Facets('main', 'always', 'author')
         annotator = StaticFeedAnnotator('https://ls.org', lane)
 
         result = self.script.create_feed_pages(
@@ -405,7 +404,7 @@ class TestStaticFeedGenerationScript(DatabaseTest):
         eq_(w1.author, entry.simplified_sort_name)
 
         [next_link] = links_by_rel(parsed, 'next')
-        eq_(next_link.href, 'https://ls.org/index_title_2.xml')
+        eq_(next_link.href, 'https://ls.org/index_author_2.xml')
         eq_([], links_by_rel(parsed, 'previous'))
         eq_([], links_by_rel(parsed, 'first'))
 
@@ -416,7 +415,7 @@ class TestStaticFeedGenerationScript(DatabaseTest):
 
         [previous_link] = links_by_rel(parsed, 'previous')
         [first_link] = links_by_rel(parsed, 'first')
-        first = 'https://ls.org/index_title.xml'
+        first = 'https://ls.org/index_author.xml'
         eq_(previous_link.href, first)
         eq_(first_link.href, first)
         eq_([], links_by_rel(parsed, 'next'))


### PR DESCRIPTION
This branch allows youth lanes to be created alongside static feed lanes from the same CSV and creates a navigation to support COPPA requests by the client.