### PR TITLE
Sort static feed lanes

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -208,7 +208,7 @@ class StaticFeedAnnotator(ContentServerAnnotator):
             OPDSFeed.add_link_to_feed(
                 feed.feed,
                 rel="search",
-                href=self.search_url,
+                href=self.search_url(),
                 type="application/opensearchdescription+xml")
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ nose
 lxml
 flask
 isbnlib
-tinys3
+tinys3==0.1.11
 textblob
 rdflib
 elasticsearch

--- a/scripts.py
+++ b/scripts.py
@@ -981,7 +981,6 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 feed = AcquisitionFeed.groups(
                     self._db, lane.name, url, lane, annotator,
                     cache_type=AcquisitionFeed.NO_CACHE,
-                    force_refresh=True,
                     use_materialized_works=False,
                 )
                 yield filename, [feed]
@@ -1022,7 +1021,6 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 facets=facet,
                 pagination=pagination,
                 cache_type=AcquisitionFeed.NO_CACHE,
-                force_refresh=True,
                 use_materialized_works=False
             )
             pages.append(page)

--- a/scripts.py
+++ b/scripts.py
@@ -764,7 +764,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 upload_files.append((filename, content))
 
         if parsed.upload:
-            representations, uploader = self.create_representations(upload_files)
+            representations, uploader = self.create_representations(upload_files, uploader=uploader)
             uploader.mirror_batch(representations)
         else:
             for filename, content in upload_files:

--- a/tests/files/scripts/languages.csv
+++ b/tests/files/scripts/languages.csv
@@ -1,0 +1,6 @@
+urn,title,author,epub,Fiction,Spanish>Fiction,Spanish>Nonfiction,French>Short Stories,German
+urn:isbn:9781682280065,Frankenstein,Mary Shelley,http://oabooks.nypl.org/ISBN/9781682280065.epub,,,,x,
+urn:isbn:9781682280003,Journey to the Center of the Earth,Jules Verne,http://oabooks.nypl.org/ISBN/9781682280003.epub,,x,,,
+urn:isbn:9781682280010,Little Women,Louisa May Alcott,http://oabooks.nypl.org/ISBN/9781682280010.epub,x,,,,
+urn:isbn:9781682280027,The Call of the Wild,Jack London,http://oabooks.nypl.org/ISBN/9781682280027.epub,,,x,,
+urn:isbn:9781682280041,The Strange Case of Dr. Jekyll and Mr. Hyde,Robert Louis Stevenson,http://oabooks.nypl.org/ISBN/9781682280041.epub,,,,,x

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -363,6 +363,19 @@ class TestStaticFeedGenerationScript(DatabaseTest):
         eq_(True, isinstance(result, StaticFeedBaseLane))
         eq_(2, len(result.identifiers))
 
+        # If the CSV includes non-English lanes, those lanes are given the
+        # proper languages.
+        csv_filename = os.path.abspath('tests/files/scripts/languages.csv')
+        top_level = self.script.make_lanes_from_csv(csv_filename)[0]
+        eq_(None, top_level.languages)
+
+        expected = dict(Fiction=None, German=['ger'], Spanish=['spa'], French=['fre'])
+
+        for lane in top_level.sublanes:
+            eq_(expected[lane.name], lane.languages)
+            for sublane in lane.sublanes:
+                eq_(expected[lane.name], sublane.languages)
+
     def test_create_feeds(self):
         omega = self._work(title='Omega', authors='Iota', with_open_access_download=True)
         alpha = self._work(title='Alpha', authors='Theta', with_open_access_download=True)

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -15,7 +15,6 @@ from ..core.lane import (
     Pagination,
 )
 from ..core.model import (
-    CachedFeed,
     Edition,
     Identifier,
     LicensePool,
@@ -361,8 +360,8 @@ class TestStaticFeedGenerationScript(DatabaseTest):
         eq_(2, len(results))
         eq_(['index', 'index_author'], sorted([r[0] for r in results]))
         for filename, [feed] in results:
-            eq_(True, isinstance(feed, CachedFeed))
-            parsed = feedparser.parse(feed.content)
+            eq_(True, isinstance(feed, unicode))
+            parsed = feedparser.parse(feed)
             [active_facet_link] = [l for l in parsed.feed.links if l.get('activefacet')]
             if filename == 'index':
                 # The entries are sorted by title, by default.
@@ -398,7 +397,7 @@ class TestStaticFeedGenerationScript(DatabaseTest):
         def links_by_rel(parsed_feed, rel):
             return [l for l in parsed_feed.feed.links if l['rel']==rel]
 
-        parsed = feedparser.parse(first.content)
+        parsed = feedparser.parse(first)
         [entry] = parsed.entries
         eq_(w1.title, entry.title)
         eq_(w1.author, entry.simplified_sort_name)
@@ -408,7 +407,7 @@ class TestStaticFeedGenerationScript(DatabaseTest):
         eq_([], links_by_rel(parsed, 'previous'))
         eq_([], links_by_rel(parsed, 'first'))
 
-        parsed = feedparser.parse(second.content)
+        parsed = feedparser.parse(second)
         [entry] = parsed.entries
         eq_(w2.title, entry.title)
         eq_(w2.author, entry.simplified_sort_name)


### PR DESCRIPTION
This branch gets static feeds into fighting shape: 
- Incorporates lane sorting, so that the small "German" lanes aren't listed above "Fiction" or "Short Stories"
- Adds prefixing (so that multiple static projects can be held in the same s3 bucket)
- Stops using CachedFeeds, which were creating a giant problem by overwriting feeds. Before this branch, all of the nonfiction feeds--no matter their languages--were the same 2 OPDS feeds. ☹️ 
- It also adds a utility method that deletes things from s3. I don't think it's required for the codebase, but I used it locally and thought it might be nice to have around.

Requires NYPL-Simplified/server_core#435.