### PR TITLE
Remove internal search url option from static feeds

### DIFF
--- a/opds.py
+++ b/opds.py
@@ -123,9 +123,8 @@ class StaticFeedAnnotator(ContentServerAnnotator):
         slug = re.sub(' {2,}', ' ', slug)
         return unicode('-'.join(slug.split(' ')))
 
-
     def __init__(self, base_url, lane=None, prefix=None, include_search=None,
-                 license_link=None, elastic_url=None):
+                 license_link=None):
         if not base_url.endswith('/'):
             base_url += '/'
         self.base_url = base_url
@@ -134,7 +133,6 @@ class StaticFeedAnnotator(ContentServerAnnotator):
         self.include_search = include_search
         self.license_link = license_link
         self.lanes_by_work = defaultdict(list)
-        self.elastic_url = elastic_url
 
     def reset(self, lane):
         self.lanes_by_work = defaultdict(list)
@@ -146,9 +144,6 @@ class StaticFeedAnnotator(ContentServerAnnotator):
 
 
     def search_url(self):
-        if self.elastic_url:
-            return self.elastic_url
-
         return self.base_url + 'search'
 
 

--- a/scripts.py
+++ b/scripts.py
@@ -695,9 +695,6 @@ class StaticFeedGenerationScript(StaticFeedScript):
             '--search-index', help='Upload to this elasticsearch index. elasticsearch-url must also be included'
         )
         parser.add_argument(
-            '--internal-elastic', help='Point to this elastic search url from inside the feed'
-        )
-        parser.add_argument(
             '--urns', metavar='URN', nargs='*',
             help='Specific identifier urns to process, esp. for testing'
         )
@@ -738,11 +735,8 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 search_index_client=search_index_client
             )
 
-        search = False
-        if parsed.search_url and parsed.search_index:
-            search = True
-        if parsed.internal_elastic:
-            search = True
+        # Determine if the feed should have a search link.
+        search = bool(parsed.search_url and parsed.search_index)
 
         feeds = list()
         if youth_lane:
@@ -752,8 +746,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 StaticFeedCOPPAAnnotator.TOP_LEVEL_LANE_NAME, feed_id,
                 youth_lane, full_lane,
                 prefix=parsed.prefix,
-                license_link=parsed.license, 
-                elastic_url=parsed.internal_elastic
+                license_link=parsed.license
             )
             prefix = parsed.prefix or ''
             feeds.append((
@@ -765,8 +758,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 feed_id, youth_lane,
                 prefix=parsed.prefix,
                 include_search=search,
-                license_link=parsed.license,
-                elastic_url=parsed.internal_elastic
+                license_link=parsed.license
             )
 
             youth_feeds = list(self.create_feeds([youth_lane], page_size, annotator))
@@ -777,8 +769,7 @@ class StaticFeedGenerationScript(StaticFeedScript):
                 feed_id, full_lane,
                 prefix=parsed.prefix,
                 include_search=search,
-                license_link=parsed.license,
-                elastic_url=parsed.internal_elastic
+                license_link=parsed.license
             )
 
         feeds += list(self.create_feeds([full_lane], page_size, annotator))

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -311,23 +311,6 @@ class TestStaticFeedGenerationScript(DatabaseTest):
             eq_(license_url, license_link.href)
             eq_('text/html', license_link.type)
 
-    def test_run_with_custom_elastic(self):
-        """Confirms that can control contents of rel=search elements 
-        in the result OPDS feeds by passing --internal-elastic parameter.
-        """
-        elastic_url = 'https://searchme.org/searcharoo.html'
-        elastic_args = ['--internal-elastic', elastic_url]
-
-        self.run_mini_csv(*elastic_args)
-
-        for content in self.uploader.content:
-            # All of the uploaded feeds have a license link with the
-            # expected URL.
-            feed = feedparser.parse(content)
-            [search_link] = [l for l in feed.feed.links if l.rel == 'search']
-            eq_(elastic_url, search_link.href)
-            eq_('application/opensearchdescription+xml', search_link.type)
-
     def test_cover_suppression(self):
         csv_content = (
             "urn,hide_cover"+


### PR DESCRIPTION
This is a quick removal of a fast fix that we pushed before the end of the year. We thought that the search URLs might have been causing search to be broken, so we wanted to try less DNS-y URL options.

The problem with search ended up being something different entirely (https://github.com/NYPL-Simplified/Simplified-iOS/issues/358, temporarily fixed by https://github.com/NYPL-Simplified/opds-search-lambda/pull/3), so I want to strip this out because it increases noise unnecessarily.