### PR TITLE
Fix script runtime

### DIFF
--- a/bibblio.py
+++ b/bibblio.py
@@ -201,9 +201,10 @@ class BibblioCoverageProvider(WorkCoverageProvider):
         )
 
         self.fiction = fiction
-        if languages and not isinstance(languages, list):
-            languages = [languages]
-        self.languages = [unicode(l) for l in languages] or []
+        self.languages = languages or []
+        if not isinstance(self.languages, list):
+            self.languages = [languages]
+        self.languages = [unicode(l) for l in self.languages]
 
         self.api = api or BibblioAPI.from_config(self._db)
         self.catalogue_id = catalogue_identifier

--- a/bibblio.py
+++ b/bibblio.py
@@ -189,16 +189,22 @@ class BibblioCoverageProvider(WorkCoverageProvider):
     ]
 
     def __init__(self, _db, custom_list_identifier,
-                 api=None, catalogue_identifier=None, fiction=False):
+                 api=None, fiction=False, languages=None,
+                 catalogue_identifier=None, **kwargs):
         super(BibblioCoverageProvider, self).__init__(
             _db, self.SERVICE_NAME, self.OPERATION,
-            batch_size=self.DEFAULT_BATCH_SIZE
+            batch_size=self.DEFAULT_BATCH_SIZE, **kwargs
         )
 
         self.custom_list = CustomList.find(
-            self._db, DataSource.LIBRARY_STAFF, custom_list_identifier
+            self._db, DataSource.LIBRARY_STAFF, unicode(custom_list_identifier)
         )
+
         self.fiction = fiction
+        if languages and not isinstance(languages, list):
+            languages = [languages]
+        self.languages = [unicode(l) for l in languages] or []
+
         self.api = api or BibblioAPI.from_config(self._db)
         self.catalogue_id = catalogue_identifier
 
@@ -231,12 +237,15 @@ class BibblioCoverageProvider(WorkCoverageProvider):
             # Only get nonfiction. This is the default setting.
             qu = qu.filter(Work.fiction==False)
 
+        if self.languages:
+            # We only want a particular language.
+            qu = qu.filter(Edition.language.in_(self.languages))
+
         return qu
 
     def process_item(self, work):
-        content_item = self.content_item_from_work(work)
-
         try:
+            content_item = self.content_item_from_work(work)
             result = self.api.create_content_item(content_item)
         except Exception as e:
             return CoverageFailure(

--- a/bibblio.py
+++ b/bibblio.py
@@ -197,14 +197,13 @@ class BibblioCoverageProvider(WorkCoverageProvider):
         )
 
         self.custom_list = CustomList.find(
-            self._db, DataSource.LIBRARY_STAFF, unicode(custom_list_identifier)
+            self._db, DataSource.LIBRARY_STAFF, custom_list_identifier
         )
 
         self.fiction = fiction
         self.languages = languages or []
         if not isinstance(self.languages, list):
             self.languages = [languages]
-        self.languages = [unicode(l) for l in self.languages]
 
         self.api = api or BibblioAPI.from_config(self._db)
         self.catalogue_id = catalogue_identifier

--- a/bin/util/basque_import
+++ b/bin/util/basque_import
@@ -5,7 +5,7 @@ import sys
 bin_dir = os.path.split(__file__)[0]
 package_dir = os.path.join(bin_dir, "..", "..")
 sys.path.append(os.path.abspath(package_dir))
-if len(sys.argv) < 3:
+if len(sys.argv) < 4:
     raise Exception("3 arguments required: metadata file, epub directory, and cover directory")
 from scripts import DirectoryImportScript
 from basque import BasqueMetadataExtractor

--- a/bin/util/bibblio_export
+++ b/bin/util/bibblio_export
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+"""Export certain works to Bibblio as Bibblio ContentItems"""
+import argparse
+import os
+import sys
+from nose.tools import set_trace
+
+bin_dir = os.path.split(__file__)[0]
+package_dir = os.path.join(bin_dir, "..", "..")
+sys.path.append(os.path.abspath(package_dir))
+
+from core.model import production_session
+from bibblio import BibblioCoverageProvider
+
+parser = argparse.ArgumentParser()
+parser.add_argument(
+    'custom_list_identifier', help='Export Works from this CustomList'
+)
+parser.add_argument(
+    'catalogue_identifier', help='Export Works into this Bibblio catalogue'
+)
+parser.add_argument(
+    '--languages', nargs='?', default='eng',
+    help='Look for Works in these languages'
+)
+
+parsed = parser.parse_args()
+
+_db = production_session()
+BibblioCoverageProvider(
+    _db, parsed.custom_list_identifier,
+    languages=parsed.languages,
+    catalogue_identifier=parsed.catalogue_identifier
+).run()

--- a/bin/util/bibblio_export
+++ b/bin/util/bibblio_export
@@ -14,13 +14,15 @@ from bibblio import BibblioCoverageProvider
 
 parser = argparse.ArgumentParser()
 parser.add_argument(
-    'custom_list_identifier', help='Export Works from this CustomList'
+    'custom_list_identifier', type=unicode,
+    help='Export Works from this CustomList'
 )
 parser.add_argument(
-    'catalogue_identifier', help='Export Works into this Bibblio catalogue'
+    'catalogue_identifier', type=unicode,
+    help='Export Works into this Bibblio catalogue'
 )
 parser.add_argument(
-    '--languages', nargs='?', default='eng',
+    '--languages', type=unicode, nargs='*', default=u'eng',
     help='Look for Works in these languages'
 )
 

--- a/scripts.py
+++ b/scripts.py
@@ -890,12 +890,17 @@ class CustomListUploadScript(StaticFeedScript):
 
         if save_option in self.ADD_OPTIONS:
             # We're just adding to what's there. No need to get fancy.
+            self.log.info("Adding %d editions to %r", len(input_editions), custom_list)
             input_editions = self.editions_with_featured_status(
                 input_editions, featured_identifiers
             )
             [custom_list.add_entry(e, featured=f) for e, f in input_editions]
 
         if save_option == 'remove':
+            self.log.info(
+                "Removing %d editions from %r",
+                len(input_editions), custom_list
+            )
             [custom_list.remove_entry(e) for e in input_editions]
 
         if save_option == 'replace':
@@ -906,8 +911,16 @@ class CustomListUploadScript(StaticFeedScript):
             overwritten_editions = self._confirm_removal(
                 custom_list, overwritten_editions, input_editions
             )
+
+            self.log.info(
+                "Removing %d editions from %r",
+                len(overwritten_editions), custom_list
+            )
             [custom_list.remove_entry(e) for e in overwritten_editions]
 
+            self.log.info(
+                "Adding %d editions to %r", len(input_editions), custom_list
+            )
             input_editions = self.editions_with_featured_status(
                 input_editions, featured_identifiers
             )

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -278,7 +278,7 @@ class TestCustomListUploadScript(DatabaseTest):
         works_qu = self._db.query(Work).filter(Work.id.in_([w.id for w in works]))
         self.script.edit_list(custom_list, works_qu, 'replace', [other_identifier])
         eq_(5, len(custom_list.entries))
-        [entry] = custom_list.entries_for_work(other_work)
+        [entry] = list(custom_list.entries_for_work(other_work))
         # Also, works that are requested to be featured, are featured.
         eq_(True, entry.featured)
 
@@ -286,7 +286,7 @@ class TestCustomListUploadScript(DatabaseTest):
         works_qu = self._db.query(Work).filter(Work.id.in_([w.id for w in sample_works]))
         self.script.edit_list(custom_list, works_qu, 'remove', [])
         eq_(1, len(custom_list.entries))
-        assert custom_list.entries_for_work(other_work)
+        assert list(custom_list.entries_for_work(other_work))
 
     def test_run(self):
         works, works_by_urn, _f = self._create_works_from_csv('youth.csv')
@@ -303,12 +303,12 @@ class TestCustomListUploadScript(DatabaseTest):
         # Only the youth works are in the youth list.
         eq_(2, len(youth_list.entries))
         for urn in youth_urns:
-            eq_(1, len(youth_list.entries_for_work(works_by_urn[urn])))
+            eq_(1, len(list(youth_list.entries_for_work(works_by_urn[urn]))))
 
         # All of the works are in the full list.
         eq_(7, len(full_list.entries))
         for urn, work in works_by_urn.items():
-            eq_(1, len(full_list.entries_for_work(work)))
+            eq_(1, len(list(full_list.entries_for_work(work))))
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
I ran into some errors while running scripts to upload to Bibblio, and this branch fixes them. It also adds a file that will run the export process and accounts for language filtering. It also adds a bit of logging.

It depends on NYPL-Simplified/server_core#493.