### PR TITLE
Add route for CustomLists

### DIFF
--- a/app.py
+++ b/app.py
@@ -64,6 +64,11 @@ def feed():
 def feed_from_license_source(license_source_name):
     return app.content_server.opds_feeds.feed(license_source_name)
 
+@app.route('/works/lists/<list_identifier>')
+@returns_problem_detail
+def feed_from_custom_list(list_identifier):
+    return app.content_server.opds_feeds.custom_list_feed(list_identifier)
+
 @app.route('/lookup')
 def lookup():
     return URNLookupController(app.content_server._db).work_lookup(ContentServerAnnotator)

--- a/controller.py
+++ b/controller.py
@@ -25,6 +25,7 @@ from core.app_server import (
 
 from core.model import (
     production_session,
+    CustomList,
     DataSource,
 )
 from core.lane import (
@@ -107,4 +108,47 @@ class OPDSFeedController(ContentServerController):
             pagination=pagination,
         )
         return feed_response(opds_feed.content) 
-        
+
+    def custom_list_feed(self, list_identifier):
+        """Creates an OPDS feed with the Works from a CustomList.
+
+        :param list_identifier: a basestring representing either the
+            name or the foreign_identifier of an existing CustomList
+
+        :return: an OPDS feed or a ProblemDetail
+        """
+        # Right now we only allow downloading of staff-created lists.
+        source = DataSource.LIBRARY_STAFF
+        custom_list = CustomList.find(self._db, source, list_identifier)
+
+        if not custom_list:
+            return INVALID_INPUT.detailed(
+                "Available CustomList '%s' not found." % list_identifier
+            )
+
+        lane_name = 'All books from %s' % custom_list.name
+        lane = Lane(
+            self._db, lane_name,
+            list_identifier=custom_list.foreign_identifier,
+        )
+
+        url = url_for(
+            'feed_from_custom_list',
+            list_identifier=custom_list.foreign_identifier,
+            _external=True
+        )
+
+        facets = load_facets_from_request(Configuration)
+        if isinstance(facets, ProblemDetail):
+            return facets
+        pagination = load_pagination_from_request()
+        if isinstance(pagination, ProblemDetail):
+            return pagination
+
+        custom_list_feed = AcquisitionFeed.page(
+            self._db, lane_name, url, lane,
+            annotator=self.annotator(),
+            facets=facets,
+            pagination=pagination,
+        )
+        return feed_response(custom_list_feed.content)


### PR DESCRIPTION
This branch adds a route to grab an OPDS feed for staff-created CustomLists. At this point, this work intended to allow open access CustomLists of some smaller lists of high-popularity titles to be fed to Circulation Managers without the need to import all 55K+ titles on the content server.

Fixes #129.