### PR TITLE
Fixed lane name in links in feed from custom list. (Fixes #137)

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -89,7 +89,7 @@ class OPDSFeedController(ContentServerController):
                 )
             lane_name = "All books from %s" % license_source.name
         else:
-            lane_name = "All books"
+            lane_name = flask.request.args.get("lane", "All books")
             license_source=None
 
         library = Library.default(self._db)


### PR DESCRIPTION
This fixes a bug I found where an import of the instant classics feed ended up in the all books lane after the second page.