### PR TITLE
Annotate feed with distributor

### DIFF
--- a/coverage.py
+++ b/coverage.py
@@ -72,14 +72,24 @@ class GutenbergEPUBCoverageProvider(IdentifierCoverageProvider):
         if isinstance(epub_path, CoverageFailure):
             return epub_path
 
-        license_pool = edition.license_pool
-        if not edition.license_pool:
+        license_pools = [
+            x for x in edition.license_pools
+            if x.data_source and x.data_source.name == DataSource.GUTENBERG
+        ]
+        if not license_pools:
             return CoverageFailure(
-                identifier, 'No license pool for %r' % edition,
+                identifier, 'No Gutenberg license pools for %r' % edition,
+                data_source=self.data_source,
+                transient=True,
+            )
+        if len(license_pools) > 1:
+            return CoverageFailure(
+                identifier, 'Multiple Gutenberg license pools for %r' % edition,
                 data_source=self.data_source,
                 transient=True,
             )
 
+        [license_pool] = license_pools
         url = self.uploader.book_url(identifier, 'epub')
         link, new = license_pool.add_link(
             Hyperlink.OPEN_ACCESS_DOWNLOAD, url, self.data_source,

--- a/opds.py
+++ b/opds.py
@@ -36,10 +36,6 @@ class ContentServerAnnotator(VerboseAnnotator):
         if not active_license_pool.open_access:
             return
 
-        VerboseAnnotator.annotate_work_entry(
-            work, active_license_pool, edition, identifier, feed, entry
-        )
-
         rel = OPDSFeed.OPEN_ACCESS_REL
         fulfillable = False
         for resource in active_license_pool.open_access_links:
@@ -63,6 +59,10 @@ class ContentServerAnnotator(VerboseAnnotator):
             # This open-access work has no usable open-access links.
             # Don't show it in the OPDS feed.
             raise UnfulfillableWork()
+
+        VerboseAnnotator.annotate_work_entry(
+            work, active_license_pool, edition, identifier, feed, entry
+        )
 
     @classmethod
     def default_lane_url(cls):

--- a/opds.py
+++ b/opds.py
@@ -36,6 +36,10 @@ class ContentServerAnnotator(VerboseAnnotator):
         if not active_license_pool.open_access:
             return
 
+        VerboseAnnotator.annotate_work_entry(
+            work, active_license_pool, edition, identifier, feed, entry
+        )
+
         rel = OPDSFeed.OPEN_ACCESS_REL
         fulfillable = False
         for resource in active_license_pool.open_access_links:


### PR DESCRIPTION
This branch brings the content server up to date with recent changes in core.

* An `annotate_work_entry` implementation needs to call the parent class implementation to make sure the `<bibframe:distribution>` tag is inserted.

* Mock responses are popped off of the queue in the same order they were added to the queue. (i.e. it's a queue now and not a stack).